### PR TITLE
Feat: Update File Viewer Constrain

### DIFF
--- a/src/components/files/index.tsx
+++ b/src/components/files/index.tsx
@@ -65,8 +65,8 @@ export const isFileViewable = (s3Key: string): boolean => {
 };
 
 export const isFileSizeAcceptable = (objectSize: number): boolean => {
-  // Only allow to view size less than 20MB - refer to file-manager settings
-  if (objectSize < 20000000) {
+  // Only allow to view size less than 50MB
+  if (objectSize < 50000000) {
     return true;
   }
   return false;

--- a/src/modules/files/components/FilePreviewDrawer.tsx
+++ b/src/modules/files/components/FilePreviewDrawer.tsx
@@ -1,6 +1,11 @@
 import React, { Suspense, useState } from 'react';
 import { Drawer } from '@/components/common/drawers';
-import { FileViewer, isFileSizeAcceptable, isFileViewable } from '@/components/files';
+import {
+  FileViewer,
+  IGV_FILETYPE_LIST,
+  isFileSizeAcceptable,
+  isFileViewable,
+} from '@/components/files';
 import { DetailedErrorBoundary } from '@/components/common/error';
 import { getFilenameFromKey } from '@/utils/commonUtils';
 import Button from '@/components/common/buttons/Button';
@@ -12,11 +17,12 @@ export const FilePreviewDrawer = ({ s3Record }: { s3Record: S3Record }) => {
   const { key: s3Key, bucket, s3ObjectId, size } = s3Record;
   const [isFilePreview, setIsFilePreview] = useState(false);
 
-  const isFileAllowed = isFileViewable(s3Key);
+  // A special case for IGV viewable size we will not check the size
+  // IGV will only request a range byte of the file
+  const isIGVFile = !!IGV_FILETYPE_LIST.find((f) => s3Key.endsWith(f));
+  const isFileSizeAllowed = isIGVFile || (size && isFileSizeAcceptable(size));
 
-  // FIX ME: Although we should not limit igv openable file, but since the presign url from FM is configured to 20MB, we
-  // would limit this for now.
-  const isFileSizeAllowed = size ? isFileSizeAcceptable(size) : false;
+  const isFileAllowed = isFileViewable(s3Key);
 
   return (
     <>

--- a/src/modules/lab/components/library/LibraryTableDetails.tsx
+++ b/src/modules/lab/components/library/LibraryTableDetails.tsx
@@ -24,7 +24,7 @@ export const LibraryTableDetails: FC<LibraryTableDetailsProps> = ({ libraryDetai
           ),
           'Sample Id': (
             <Link
-              to={`/lab/?tab=subject&orcabusId=${library.sample.orcabusId}`}
+              to={`/lab/?tab=sample&orcabusId=${library.sample.orcabusId}`}
               className={classNames('hover:text-blue-700 text-blue-500')}
             >
               {library.sample.sampleId ?? '-'}


### PR DESCRIPTION
- Increase viewable file size to 50MB except for IGV viewable file types

Followup action after https://github.com/umccr/orcabus/issues/687