### PR TITLE
Feat: Enhance API List Filtering

### DIFF
--- a/src/api/types/file.d.ts
+++ b/src/api/types/file.d.ts
@@ -35,10 +35,8 @@ export interface paths {
         delete?: never;
         options?: never;
         head?: never;
-        /**
-         * Update the attributes for a collection of s3_objects using a JSON patch request.
-         * @description This updates all attributes matching the filter params with the same JSON patch.
-         */
+        /** Update the attributes for a collection of s3_objects using a JSON patch request.
+         *     This updates all attributes matching the filter params with the same JSON patch. */
         patch: operations["update_s3_collection_attributes"];
         trace?: never;
     };
@@ -49,14 +47,12 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /**
-         * List all S3 objects according to a set of attribute filter parameters.
-         * @description This route is a convenience for querying using top-level attributes and accepts arbitrary
+        /** List all S3 objects according to a set of attribute filter parameters.
+         *     This route is a convenience for querying using top-level attributes and accepts arbitrary
          *     parameters. For example, instead of using `/api/v1/s3?attributes[attributeId]=...`, this route
          *     can express the same query as `/api/v1/s3/attributes?attributeId=...`. Similar to the
          *     `attributes` filter parameter, nested JSON queries are supported using the bracket notation.
-         *     Note that regular filtering parameters, like `key` or `bucket` are not supported on this route.
-         */
+         *     Note that regular filtering parameters, like `key` or `bucket` are not supported on this route. */
         get: operations["attributes_s3"];
         put?: never;
         post?: never;
@@ -90,12 +86,10 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /**
-         * Generate AWS presigned URLs for s3_objects according to the parameters.
-         * @description This route implies `currentState=true` because only existing objects can be presigned.
+        /** Generate AWS presigned URLs for s3_objects according to the parameters.
+         *     This route implies `currentState=true` because only existing objects can be presigned.
          *     Less presigned URLs may be returned than the amount of objects in the database because some
-         *     objects may be over the `FILEMANAGER_API_PRESIGN_LIMIT`.
-         */
+         *     objects may be over the `FILEMANAGER_API_PRESIGN_LIMIT`. */
         get: operations["presign_s3"];
         put?: never;
         post?: never;
@@ -112,11 +106,9 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /**
-         * Generate AWS presigned URLs for a single S3 object using its `s3_object_id`.
-         * @description This route will not return an object if it has been deleted from the database, or its size
-         *     is greater than `FILEMANAGER_API_PRESIGN_LIMIT`.
-         */
+        /** Generate AWS presigned URLs for a single S3 object using its `s3_object_id`.
+         *     This route will not return an object if it has been deleted from the database, or its size
+         *     is greater than `FILEMANAGER_API_PRESIGN_LIMIT`. */
         get: operations["presign_s3_by_id"];
         put?: never;
         post?: never;
@@ -164,11 +156,56 @@ export interface components {
         };
         /** @enum {string} */
         EventType: "Created" | "Deleted" | "Other";
+        /** @description Specifies how to join multiple queries with the same key. Either with
+         *     'or' or 'and' logic. The default is combining using `or` logic for multiple
+         *     keys. For example, use `?key[]=123&key[]=456` to query where `key=123`
+         *     or `key=456`. The same query can be expressed more explicitly as
+         *     `?key[or][]=123&key[or][]=456`. `and` logic can be expressed using the `and`
+         *     keyword. For example, use`?key[and][]=*123*&key[and][]=*345` to query where
+         *     the key contains `123` and ends with `345`. */
+        FilterJoin_StorageClass: ("DeepArchive" | "Glacier" | "GlacierIr" | "IntelligentTiering" | "OnezoneIa" | "Outposts" | "ReducedRedundancy" | "Snow" | "Standard" | "StandardIa") | Record<string, never>[] | {
+            [key: string]: Record<string, never>[];
+        };
+        /** @description Specifies how to join multiple queries with the same key. Either with
+         *     'or' or 'and' logic. The default is combining using `or` logic for multiple
+         *     keys. For example, use `?key[]=123&key[]=456` to query where `key=123`
+         *     or `key=456`. The same query can be expressed more explicitly as
+         *     `?key[or][]=123&key[or][]=456`. `and` logic can be expressed using the `and`
+         *     keyword. For example, use`?key[and][]=*123*&key[and][]=*345` to query where
+         *     the key contains `123` and ends with `345`. */
+        FilterJoin_String: string | Record<string, never>[] | {
+            [key: string]: Record<string, never>[];
+        };
+        /** @description Specifies how to join multiple queries with the same key. Either with
+         *     'or' or 'and' logic. The default is combining using `or` logic for multiple
+         *     keys. For example, use `?key[]=123&key[]=456` to query where `key=123`
+         *     or `key=456`. The same query can be expressed more explicitly as
+         *     `?key[or][]=123&key[or][]=456`. `and` logic can be expressed using the `and`
+         *     keyword. For example, use`?key[and][]=*123*&key[and][]=*345` to query where
+         *     the key contains `123` and ends with `345`. */
+        FilterJoin_Wildcard: string | Record<string, never>[] | {
+            [key: string]: Record<string, never>[];
+        };
+        /** @description Specifies how to join multiple queries with the same key. Either with
+         *     'or' or 'and' logic. The default is combining using `or` logic for multiple
+         *     keys. For example, use `?key[]=123&key[]=456` to query where `key=123`
+         *     or `key=456`. The same query can be expressed more explicitly as
+         *     `?key[or][]=123&key[or][]=456`. `and` logic can be expressed using the `and`
+         *     keyword. For example, use`?key[and][]=*123*&key[and][]=*345` to query where
+         *     the key contains `123` and ends with `345`. */
+        FilterJoin_i64: number | Record<string, never>[] | {
+            [key: string]: Record<string, never>[];
+        };
         /** @description The return value for ingest endpoints indicating how many records were processed. */
         IngestCount: {
             /** @description The number of events processed. This potentially includes duplicate records. */
             nRecords: number;
         };
+        /**
+         * @description The logical query join type.
+         * @enum {string}
+         */
+        Join: "or" | "and";
         /** @description A newtype equivalent to an arbitrary JSON `Value`. */
         Json: unknown;
         /** @description The paginated links to the next and previous page. */
@@ -193,15 +230,48 @@ export interface components {
             nRecords: number;
         };
         /** @description The response type for list operations. */
-        ListResponseS3: {
+        ListResponse_S3: {
+            /** @description Links to next and previous page. */
             links: components["schemas"]["Links"];
+            /** @description The pagination response component. */
             pagination: components["schemas"]["PaginatedResponse"];
             /** @description The results of the list operation. */
-            results: components["schemas"]["S3"][];
+            results: {
+                attributes?: null | components["schemas"]["Value"];
+                bucket: string;
+                /** Format: date-time */
+                deletedDate?: string | null;
+                deletedSequencer?: string | null;
+                eTag?: string | null;
+                /** Format: date-time */
+                eventTime?: string | null;
+                eventType: components["schemas"]["EventType"];
+                /** Format: uuid */
+                ingestId?: string | null;
+                isCurrentState: boolean;
+                isDeleteMarker: boolean;
+                key: string;
+                /** Format: date-time */
+                lastModifiedDate?: string | null;
+                /** Format: int64 */
+                numberDuplicateEvents: number;
+                /** Format: int64 */
+                numberReordered: number;
+                /** Format: uuid */
+                s3ObjectId: string;
+                sequencer?: string | null;
+                sha256?: string | null;
+                /** Format: int64 */
+                size?: number | null;
+                storageClass?: null | components["schemas"]["StorageClass"];
+                versionId: string;
+            }[];
         };
         /** @description The response type for list operations. */
-        ListResponseUrl: {
+        ListResponse_String: {
+            /** @description Links to next and previous page. */
             links: components["schemas"]["Links"];
+            /** @description The pagination response component. */
             pagination: components["schemas"]["PaginatedResponse"];
             /** @description The results of the list operation. */
             results: string[];
@@ -252,22 +322,26 @@ export interface components {
          *     ]
          */
         PatchBody: {
+            /** @description The JSON patch for a record's attributes. */
             attributes: components["schemas"]["Patch"];
         } | components["schemas"]["Patch"];
         S3: {
-            attributes?: components["schemas"]["Json"] | null;
+            attributes?: null | components["schemas"]["Value"];
             bucket: string;
-            deletedDate?: components["schemas"]["DateTimeWithTimeZone"] | null;
+            /** Format: date-time */
+            deletedDate?: string | null;
             deletedSequencer?: string | null;
             eTag?: string | null;
-            eventTime?: components["schemas"]["DateTimeWithTimeZone"] | null;
+            /** Format: date-time */
+            eventTime?: string | null;
             eventType: components["schemas"]["EventType"];
             /** Format: uuid */
             ingestId?: string | null;
             isCurrentState: boolean;
             isDeleteMarker: boolean;
             key: string;
-            lastModifiedDate?: components["schemas"]["DateTimeWithTimeZone"] | null;
+            /** Format: date-time */
+            lastModifiedDate?: string | null;
             /** Format: int64 */
             numberDuplicateEvents: number;
             /** Format: int64 */
@@ -278,11 +352,12 @@ export interface components {
             sha256?: string | null;
             /** Format: int64 */
             size?: number | null;
-            storageClass?: components["schemas"]["StorageClass"] | null;
+            storageClass?: null | components["schemas"]["StorageClass"];
             versionId: string;
         };
         /** @enum {string} */
         StorageClass: "DeepArchive" | "Glacier" | "GlacierIr" | "IntelligentTiering" | "OnezoneIa" | "Outposts" | "ReducedRedundancy" | "Snow" | "Standard" | "StandardIa";
+        Value: unknown;
         /** @description A wildcard type represents a filter to match arbitrary characters. Use '%' for multiple characters
          *     and '_' for a single character. Use '\\' to escape these characters. Wildcards are converted to
          *     postgres `like` or `ilike` queries. */
@@ -367,45 +442,55 @@ export interface operations {
                  *     `?current_state=true` would return only the last `Created` event. */
                 currentState?: boolean;
                 /** @description Query by event type. */
-                eventType?: components["schemas"]["EventType"] | null;
+                eventType?: null | components["schemas"]["EventType"];
                 /** @description Query by bucket. Supports wildcards.
-                 *     Repeated parameters are joined with an `or` condition. */
-                bucket?: components["schemas"]["Wildcard"][];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                bucket?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by key. Supports wildcards.
-                 *     Repeated parameters are joined with an `or` condition. */
-                key?: components["schemas"]["Wildcard"][];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                key?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by version_id. Supports wildcards.
-                 *     Repeated parameters are joined with an `or` condition. */
-                versionId?: components["schemas"]["Wildcard"][];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                versionId?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by event_time. Supports wildcards.
-                 *     Repeated parameters are joined with an `or` condition. */
-                eventTime?: components["schemas"]["Wildcard"];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                eventTime?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by size.
-                 *     Repeated parameters are joined with an `or` condition. */
-                size?: number[];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                size?: components["schemas"]["FilterJoin_i64"];
                 /** @description Query by the sha256 checksum.
-                 *     Repeated parameters are joined with an `or` condition. */
-                sha256?: string[];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                sha256?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by the last modified date. Supports wildcards.
-                 *     Repeated parameters are joined with an `or` condition. */
-                lastModifiedDate?: components["schemas"]["Wildcard"];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                lastModifiedDate?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by the e_tag.
-                 *     Repeated parameters are joined with an `or` condition. */
-                eTag?: string[];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                eTag?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by the storage class.
-                 *     Repeated parameters are joined with an `or` condition. */
-                storageClass?: components["schemas"]["StorageClass"][];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                storageClass?: components["schemas"]["FilterJoin_StorageClass"];
                 /** @description Query by the object delete marker. */
                 isDeleteMarker?: boolean | null;
                 /** @description Query by the ingest id that objects get tagged with.
-                 *     Repeated parameters are joined with an `or` condition. */
-                ingestId?: string[];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                ingestId?: components["schemas"]["FilterJoin_String"];
                 /** @description Query by JSON attributes. Supports nested syntax to access inner
                  *     fields, e.g. `attributes[attribute_id]=...`. This only deserializes
                  *     into string fields, and does not support other JSON types. E.g.
                  *     `attributes[attribute_id]=1` converts to `{ "attribute_id" = "1" }`
                  *     rather than `{ "attribute_id" = 1 }`. Supports wildcards. */
-                attributes?: components["schemas"]["Json"] | null;
+                attributes?: null | components["schemas"]["Value"];
             };
             header?: never;
             path?: never;
@@ -419,7 +504,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ListResponseS3"];
+                    "application/json": components["schemas"]["ListResponse_S3"];
                 };
             };
             /** @description the request could not be parsed or the request triggered a constraint error in the database */
@@ -468,45 +553,55 @@ export interface operations {
                  *     `?current_state=true` would return only the last `Created` event. */
                 currentState?: boolean;
                 /** @description Query by event type. */
-                eventType?: components["schemas"]["EventType"] | null;
+                eventType?: null | components["schemas"]["EventType"];
                 /** @description Query by bucket. Supports wildcards.
-                 *     Repeated parameters are joined with an `or` condition. */
-                bucket?: components["schemas"]["Wildcard"][];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                bucket?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by key. Supports wildcards.
-                 *     Repeated parameters are joined with an `or` condition. */
-                key?: components["schemas"]["Wildcard"][];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                key?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by version_id. Supports wildcards.
-                 *     Repeated parameters are joined with an `or` condition. */
-                versionId?: components["schemas"]["Wildcard"][];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                versionId?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by event_time. Supports wildcards.
-                 *     Repeated parameters are joined with an `or` condition. */
-                eventTime?: components["schemas"]["Wildcard"];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                eventTime?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by size.
-                 *     Repeated parameters are joined with an `or` condition. */
-                size?: number[];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                size?: components["schemas"]["FilterJoin_i64"];
                 /** @description Query by the sha256 checksum.
-                 *     Repeated parameters are joined with an `or` condition. */
-                sha256?: string[];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                sha256?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by the last modified date. Supports wildcards.
-                 *     Repeated parameters are joined with an `or` condition. */
-                lastModifiedDate?: components["schemas"]["Wildcard"];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                lastModifiedDate?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by the e_tag.
-                 *     Repeated parameters are joined with an `or` condition. */
-                eTag?: string[];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                eTag?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by the storage class.
-                 *     Repeated parameters are joined with an `or` condition. */
-                storageClass?: components["schemas"]["StorageClass"][];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                storageClass?: components["schemas"]["FilterJoin_StorageClass"];
                 /** @description Query by the object delete marker. */
                 isDeleteMarker?: boolean | null;
                 /** @description Query by the ingest id that objects get tagged with.
-                 *     Repeated parameters are joined with an `or` condition. */
-                ingestId?: string[];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                ingestId?: components["schemas"]["FilterJoin_String"];
                 /** @description Query by JSON attributes. Supports nested syntax to access inner
                  *     fields, e.g. `attributes[attribute_id]=...`. This only deserializes
                  *     into string fields, and does not support other JSON types. E.g.
                  *     `attributes[attribute_id]=1` converts to `{ "attribute_id" = "1" }`
                  *     rather than `{ "attribute_id" = 1 }`. Supports wildcards. */
-                attributes?: components["schemas"]["Json"] | null;
+                attributes?: null | components["schemas"]["Value"];
             };
             header?: never;
             path?: never;
@@ -580,7 +675,7 @@ export interface operations {
                  *     `?current_state=true` would return only the last `Created` event. */
                 currentState?: boolean;
                 params?: {
-                    [key: string]: components["schemas"]["Json"];
+                    [key: string]: components["schemas"]["Value"];
                 };
             };
             header?: never;
@@ -595,7 +690,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ListResponseS3"];
+                    "application/json": components["schemas"]["ListResponse_S3"];
                 };
             };
             /** @description the request could not be parsed or the request triggered a constraint error in the database */
@@ -644,45 +739,55 @@ export interface operations {
                  *     `?current_state=true` would return only the last `Created` event. */
                 currentState?: boolean;
                 /** @description Query by event type. */
-                eventType?: components["schemas"]["EventType"] | null;
+                eventType?: null | components["schemas"]["EventType"];
                 /** @description Query by bucket. Supports wildcards.
-                 *     Repeated parameters are joined with an `or` condition. */
-                bucket?: components["schemas"]["Wildcard"][];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                bucket?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by key. Supports wildcards.
-                 *     Repeated parameters are joined with an `or` condition. */
-                key?: components["schemas"]["Wildcard"][];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                key?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by version_id. Supports wildcards.
-                 *     Repeated parameters are joined with an `or` condition. */
-                versionId?: components["schemas"]["Wildcard"][];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                versionId?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by event_time. Supports wildcards.
-                 *     Repeated parameters are joined with an `or` condition. */
-                eventTime?: components["schemas"]["Wildcard"];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                eventTime?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by size.
-                 *     Repeated parameters are joined with an `or` condition. */
-                size?: number[];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                size?: components["schemas"]["FilterJoin_i64"];
                 /** @description Query by the sha256 checksum.
-                 *     Repeated parameters are joined with an `or` condition. */
-                sha256?: string[];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                sha256?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by the last modified date. Supports wildcards.
-                 *     Repeated parameters are joined with an `or` condition. */
-                lastModifiedDate?: components["schemas"]["Wildcard"];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                lastModifiedDate?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by the e_tag.
-                 *     Repeated parameters are joined with an `or` condition. */
-                eTag?: string[];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                eTag?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by the storage class.
-                 *     Repeated parameters are joined with an `or` condition. */
-                storageClass?: components["schemas"]["StorageClass"][];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                storageClass?: components["schemas"]["FilterJoin_StorageClass"];
                 /** @description Query by the object delete marker. */
                 isDeleteMarker?: boolean | null;
                 /** @description Query by the ingest id that objects get tagged with.
-                 *     Repeated parameters are joined with an `or` condition. */
-                ingestId?: string[];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                ingestId?: components["schemas"]["FilterJoin_String"];
                 /** @description Query by JSON attributes. Supports nested syntax to access inner
                  *     fields, e.g. `attributes[attribute_id]=...`. This only deserializes
                  *     into string fields, and does not support other JSON types. E.g.
                  *     `attributes[attribute_id]=1` converts to `{ "attribute_id" = "1" }`
                  *     rather than `{ "attribute_id" = 1 }`. Supports wildcards. */
-                attributes?: components["schemas"]["Json"] | null;
+                attributes?: null | components["schemas"]["Value"];
             };
             header?: never;
             path?: never;
@@ -746,45 +851,55 @@ export interface operations {
                  *     This sets the `response-content-disposition` for the presigned `GetObject` request. */
                 responseContentDisposition?: components["schemas"]["ContentDisposition"];
                 /** @description Query by event type. */
-                eventType?: components["schemas"]["EventType"] | null;
+                eventType?: null | components["schemas"]["EventType"];
                 /** @description Query by bucket. Supports wildcards.
-                 *     Repeated parameters are joined with an `or` condition. */
-                bucket?: components["schemas"]["Wildcard"][];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                bucket?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by key. Supports wildcards.
-                 *     Repeated parameters are joined with an `or` condition. */
-                key?: components["schemas"]["Wildcard"][];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                key?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by version_id. Supports wildcards.
-                 *     Repeated parameters are joined with an `or` condition. */
-                versionId?: components["schemas"]["Wildcard"][];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                versionId?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by event_time. Supports wildcards.
-                 *     Repeated parameters are joined with an `or` condition. */
-                eventTime?: components["schemas"]["Wildcard"];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                eventTime?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by size.
-                 *     Repeated parameters are joined with an `or` condition. */
-                size?: number[];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                size?: components["schemas"]["FilterJoin_i64"];
                 /** @description Query by the sha256 checksum.
-                 *     Repeated parameters are joined with an `or` condition. */
-                sha256?: string[];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                sha256?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by the last modified date. Supports wildcards.
-                 *     Repeated parameters are joined with an `or` condition. */
-                lastModifiedDate?: components["schemas"]["Wildcard"];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                lastModifiedDate?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by the e_tag.
-                 *     Repeated parameters are joined with an `or` condition. */
-                eTag?: string[];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                eTag?: components["schemas"]["FilterJoin_Wildcard"];
                 /** @description Query by the storage class.
-                 *     Repeated parameters are joined with an `or` condition. */
-                storageClass?: components["schemas"]["StorageClass"][];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                storageClass?: components["schemas"]["FilterJoin_StorageClass"];
                 /** @description Query by the object delete marker. */
                 isDeleteMarker?: boolean | null;
                 /** @description Query by the ingest id that objects get tagged with.
-                 *     Repeated parameters are joined with an `or` condition. */
-                ingestId?: string[];
+                 *     Repeated parameters with `[]` are joined with an `or` conditions by default.
+                 *     Use `[or][]` or `[and][]` to explicitly set the joining logic. */
+                ingestId?: components["schemas"]["FilterJoin_String"];
                 /** @description Query by JSON attributes. Supports nested syntax to access inner
                  *     fields, e.g. `attributes[attribute_id]=...`. This only deserializes
                  *     into string fields, and does not support other JSON types. E.g.
                  *     `attributes[attribute_id]=1` converts to `{ "attribute_id" = "1" }`
                  *     rather than `{ "attribute_id" = 1 }`. Supports wildcards. */
-                attributes?: components["schemas"]["Json"] | null;
+                attributes?: null | components["schemas"]["Value"];
             };
             header?: never;
             path?: never;
@@ -798,7 +913,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ListResponseUrl"];
+                    "application/json": components["schemas"]["ListResponse_String"];
                 };
             };
             /** @description the request could not be parsed or the request triggered a constraint error in the database */

--- a/src/api/types/metadata.d.ts
+++ b/src/api/types/metadata.d.ts
@@ -31,10 +31,10 @@ export interface paths {
         get: operations["contactRetrieve"];
         put?: never;
         post?: never;
-        delete?: never;
+        delete: operations["contactDestroy"];
         options?: never;
         head?: never;
-        patch?: never;
+        patch: operations["contactPartialUpdate"];
         trace?: never;
     };
     "/api/v1/contact/{orcabusId}/history/": {
@@ -81,10 +81,10 @@ export interface paths {
         get: operations["individualRetrieve"];
         put?: never;
         post?: never;
-        delete?: never;
+        delete: operations["individualDestroy"];
         options?: never;
         head?: never;
-        patch?: never;
+        patch: operations["individualPartialUpdate"];
         trace?: never;
     };
     "/api/v1/individual/{orcabusId}/history/": {
@@ -131,10 +131,10 @@ export interface paths {
         get: operations["libraryRetrieve"];
         put?: never;
         post?: never;
-        delete?: never;
+        delete: operations["libraryDestroy"];
         options?: never;
         head?: never;
-        patch?: never;
+        patch: operations["libraryPartialUpdate"];
         trace?: never;
     };
     "/api/v1/library/{orcabusId}/history/": {
@@ -181,10 +181,10 @@ export interface paths {
         get: operations["projectRetrieve"];
         put?: never;
         post?: never;
-        delete?: never;
+        delete: operations["projectDestroy"];
         options?: never;
         head?: never;
-        patch?: never;
+        patch: operations["projectPartialUpdate"];
         trace?: never;
     };
     "/api/v1/project/{orcabusId}/history/": {
@@ -231,10 +231,10 @@ export interface paths {
         get: operations["sampleRetrieve"];
         put?: never;
         post?: never;
-        delete?: never;
+        delete: operations["sampleDestroy"];
         options?: never;
         head?: never;
-        patch?: never;
+        patch: operations["samplePartialUpdate"];
         trace?: never;
     };
     "/api/v1/sample/{orcabusId}/history/": {
@@ -281,10 +281,10 @@ export interface paths {
         get: operations["subjectRetrieve"];
         put?: never;
         post?: never;
-        delete?: never;
+        delete: operations["subjectDestroy"];
         options?: never;
         head?: never;
-        patch?: never;
+        patch: operations["subjectPartialUpdate"];
         trace?: never;
     };
     "/api/v1/subject/{orcabusId}/history/": {
@@ -693,6 +693,48 @@ export interface components {
             };
             results: components["schemas"]["SubjectHistory"][];
         };
+        PatchedContact: {
+            readonly orcabusId?: string;
+            contactId?: string | null;
+            name?: string | null;
+            description?: string | null;
+            /** Format: email */
+            email?: string | null;
+        };
+        PatchedIndividual: {
+            readonly orcabusId?: string;
+            individualId?: string | null;
+            source?: string | null;
+        };
+        PatchedLibrary: {
+            readonly orcabusId?: string;
+            libraryId?: string | null;
+            phenotype?: (components["schemas"]["PhenotypeEnum"] | components["schemas"]["BlankEnum"] | components["schemas"]["NullEnum"]) | null;
+            workflow?: (components["schemas"]["WorkflowEnum"] | components["schemas"]["BlankEnum"] | components["schemas"]["NullEnum"]) | null;
+            quality?: (components["schemas"]["QualityEnum"] | components["schemas"]["BlankEnum"] | components["schemas"]["NullEnum"]) | null;
+            type?: (components["schemas"]["TypeEnum"] | components["schemas"]["BlankEnum"] | components["schemas"]["NullEnum"]) | null;
+            assay?: string | null;
+            /** Format: double */
+            coverage?: number | null;
+            sample?: string | null;
+            subject?: string | null;
+        };
+        PatchedProject: {
+            readonly orcabusId?: string;
+            projectId?: string | null;
+            name?: string | null;
+            description?: string | null;
+        };
+        PatchedSample: {
+            readonly orcabusId?: string;
+            sampleId?: string | null;
+            externalSampleId?: string | null;
+            source?: (components["schemas"]["SourceEnum"] | components["schemas"]["BlankEnum"] | components["schemas"]["NullEnum"]) | null;
+        };
+        PatchedSubject: {
+            readonly orcabusId?: string;
+            subjectId?: string | null;
+        };
         /**
          * @description * `normal` - Normal
          *     * `tumor` - Tumor
@@ -902,6 +944,55 @@ export interface operations {
             };
         };
     };
+    contactDestroy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique value identifying this contact. */
+                orcabusId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No response body */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    contactPartialUpdate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique value identifying this contact. */
+                orcabusId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/x-www-form-urlencoded": components["schemas"]["PatchedContact"];
+                "multipart/form-data": components["schemas"]["PatchedContact"];
+                "application/json": components["schemas"]["PatchedContact"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Contact"];
+                };
+            };
+        };
+    };
     contactHistoryList: {
         parameters: {
             query?: {
@@ -983,6 +1074,55 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["IndividualDetail"];
+                };
+            };
+        };
+    };
+    individualDestroy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique value identifying this individual. */
+                orcabusId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No response body */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    individualPartialUpdate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique value identifying this individual. */
+                orcabusId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/x-www-form-urlencoded": components["schemas"]["PatchedIndividual"];
+                "multipart/form-data": components["schemas"]["PatchedIndividual"];
+                "application/json": components["schemas"]["PatchedIndividual"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Individual"];
                 };
             };
         };
@@ -1110,6 +1250,55 @@ export interface operations {
             };
         };
     };
+    libraryDestroy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique value identifying this library. */
+                orcabusId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No response body */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    libraryPartialUpdate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique value identifying this library. */
+                orcabusId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/x-www-form-urlencoded": components["schemas"]["PatchedLibrary"];
+                "multipart/form-data": components["schemas"]["PatchedLibrary"];
+                "application/json": components["schemas"]["PatchedLibrary"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Library"];
+                };
+            };
+        };
+    };
     libraryHistoryList: {
         parameters: {
             query?: {
@@ -1195,6 +1384,55 @@ export interface operations {
             };
         };
     };
+    projectDestroy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique value identifying this project. */
+                orcabusId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No response body */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    projectPartialUpdate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique value identifying this project. */
+                orcabusId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/x-www-form-urlencoded": components["schemas"]["PatchedProject"];
+                "multipart/form-data": components["schemas"]["PatchedProject"];
+                "application/json": components["schemas"]["PatchedProject"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Project"];
+                };
+            };
+        };
+    };
     projectHistoryList: {
         parameters: {
             query?: {
@@ -1230,6 +1468,8 @@ export interface operations {
         parameters: {
             query?: {
                 externalSampleId?: string | null;
+                /** @description Filter where it is not linked to a library. */
+                isLibraryNone?: boolean;
                 orcabusId?: string;
                 /** @description Which field to use when ordering the results. */
                 ordering?: string;
@@ -1299,6 +1539,55 @@ export interface operations {
             };
         };
     };
+    sampleDestroy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique value identifying this sample. */
+                orcabusId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No response body */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    samplePartialUpdate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique value identifying this sample. */
+                orcabusId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/x-www-form-urlencoded": components["schemas"]["PatchedSample"];
+                "multipart/form-data": components["schemas"]["PatchedSample"];
+                "application/json": components["schemas"]["PatchedSample"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Sample"];
+                };
+            };
+        };
+    };
     sampleHistoryList: {
         parameters: {
             query?: {
@@ -1333,6 +1622,8 @@ export interface operations {
     subjectList: {
         parameters: {
             query?: {
+                /** @description Filter where it is not linked to a library. */
+                isLibraryNone?: boolean;
                 /** @description Filter based on 'library_id' of the library associated with the subject. */
                 libraryId?: string;
                 /** @description Filter based on 'orcabus_id' of the library associated with the subject. */
@@ -1382,6 +1673,55 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["SubjectDetail"];
+                };
+            };
+        };
+    };
+    subjectDestroy: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique value identifying this subject. */
+                orcabusId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No response body */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    subjectPartialUpdate: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description A unique value identifying this subject. */
+                orcabusId: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/x-www-form-urlencoded": components["schemas"]["PatchedSubject"];
+                "multipart/form-data": components["schemas"]["PatchedSubject"];
+                "application/json": components["schemas"]["PatchedSubject"];
+            };
+        };
+        responses: {
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["Subject"];
                 };
             };
         };

--- a/src/components/tables/Table.tsx
+++ b/src/components/tables/Table.tsx
@@ -114,9 +114,8 @@ const Table: FC<TableProps> = ({
                             {column.sortDirection && (
                               <span className='visible ml-2 flex-none rounded text-gray-400'>
                                 <ChevronDownIcon
-                                  aria-hidden='true'
                                   className={classNames(
-                                    'w-5 h-5 cursor-pointer stroke-gray-500 opacity-0 group-hover:opacity-100 transition-opacity duration-200',
+                                    'w-5 h-5 cursor-pointer stroke-gray-500 opacity-100 transition-opacity duration-200',
                                     column.sortDirection === 'asc' ? '-rotate-180' : 'rotate-0'
                                   )}
                                 />

--- a/src/modules/files/components/InputBadgeBox.tsx
+++ b/src/modules/files/components/InputBadgeBox.tsx
@@ -18,7 +18,7 @@ interface InputBadgeBoxProps {
   inputDraft: string;
   setInput: React.Dispatch<React.SetStateAction<InputBadgeBoxType>>;
   placeholder: string;
-  badgeType: (value: string) => 'primary' | 'secondary' | 'warning' | 'unknown';
+  badgeType: (value: string) => 'primary' | 'secondary' | 'warning' | 'success' | 'unknown';
   operator: 'and' | 'or';
   setOperator: (operator: 'and' | 'or') => void;
   allowedOperator: ('and' | 'or')[];

--- a/src/modules/files/components/InputBadgeBox.tsx
+++ b/src/modules/files/components/InputBadgeBox.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { Badge } from '@/components/common/badges';
+import { XMarkIcon } from '@heroicons/react/16/solid';
+import { Dropdown } from '@/components/common/dropdowns';
+import { Tooltip } from '@/components/common/tooltips';
+import { InformationCircleIcon } from '@heroicons/react/24/outline';
+
+interface InputBadgeBoxType {
+  operator: 'and' | 'or';
+  inputState: string[];
+  inputDraft: string;
+}
+
+interface InputBadgeBoxProps {
+  label: string;
+  tooltipText?: string;
+  inputState: string[];
+  inputDraft: string;
+  setInput: React.Dispatch<React.SetStateAction<InputBadgeBoxType>>;
+  placeholder: string;
+  badgeType: (value: string) => 'primary' | 'secondary' | 'warning' | 'unknown';
+  operator: 'and' | 'or';
+  setOperator: (operator: 'and' | 'or') => void;
+  allowedOperator: ('and' | 'or')[];
+}
+
+const InputBadgeBox: React.FC<InputBadgeBoxProps> = ({
+  label,
+  tooltipText,
+  inputState,
+  inputDraft,
+  setInput,
+  placeholder,
+  badgeType,
+  operator,
+  setOperator,
+  allowedOperator,
+}) => {
+  const handleAddInput = () => {
+    if (inputDraft && !inputState.includes(inputDraft)) {
+      setInput((prev) => ({
+        ...prev,
+        inputState: [...prev.inputState, inputDraft],
+        inputDraft: '',
+      }));
+    } else {
+      setInput((prev) => ({
+        ...prev,
+        inputDraft: '',
+      }));
+    }
+  };
+
+  return (
+    <div className='flex flex-row items-center mt-2'>
+      <div className='w-28 text-sm flex flex-row'>
+        {label}
+        {tooltipText && (
+          <Tooltip text={tooltipText} position='right' background='white'>
+            <InformationCircleIcon className='mx-2 h-5 2-5' />
+          </Tooltip>
+        )}
+      </div>
+      <div className='rounded-lg w-full border py-1 px-1 flex flex-wrap'>
+        {inputState.map((key, index) => (
+          <Badge className='mx-1 my-1' key={`key-filter-${index}`} type={badgeType(key)}>
+            {key}
+            <div className='pl-2 '>
+              <XMarkIcon />
+            </div>
+            <div
+              className='inline cursor-pointer'
+              onClick={() => {
+                setInput((prev) => ({
+                  ...prev,
+                  inputState: prev.inputState.filter((val) => val !== key),
+                }));
+              }}
+            >
+              <XMarkIcon aria-hidden='true' className='h-3 w-3' />
+            </div>
+          </Badge>
+        ))}
+        <input
+          className='flex-grow min-w-60 text-sm px-2 py-2 focus-visible:outline-none border-none'
+          onBlur={handleAddInput}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              handleAddInput();
+            }
+          }}
+          onChange={(e) => {
+            setInput((prev) => ({
+              ...prev,
+              inputDraft: e.target.value.trim(),
+            }));
+          }}
+          value={inputDraft}
+          placeholder={placeholder}
+        />
+        <Dropdown
+          value={operator.toUpperCase()}
+          items={[
+            {
+              label: 'AND',
+              onClick: () => setOperator('and'),
+            },
+            {
+              label: 'OR',
+              onClick: () => setOperator('or'),
+            },
+          ].filter((item) => allowedOperator.includes(item.label.toLowerCase() as 'and' | 'or'))}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default InputBadgeBox;

--- a/src/modules/files/components/InputBadgeBox.tsx
+++ b/src/modules/files/components/InputBadgeBox.tsx
@@ -81,36 +81,38 @@ const InputBadgeBox: React.FC<InputBadgeBoxProps> = ({
             </div>
           </Badge>
         ))}
-        <input
-          className='flex-grow min-w-60 text-sm px-2 py-2 focus-visible:outline-none border-none'
-          onBlur={handleAddInput}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              handleAddInput();
-            }
-          }}
-          onChange={(e) => {
-            setInput((prev) => ({
-              ...prev,
-              inputDraft: e.target.value.trim(),
-            }));
-          }}
-          value={inputDraft}
-          placeholder={placeholder}
-        />
-        <Dropdown
-          value={operator.toUpperCase()}
-          items={[
-            {
-              label: 'AND',
-              onClick: () => setOperator('and'),
-            },
-            {
-              label: 'OR',
-              onClick: () => setOperator('or'),
-            },
-          ].filter((item) => allowedOperator.includes(item.label.toLowerCase() as 'and' | 'or'))}
-        />
+        <span className='min-w-80 flex flex-row flex-grow'>
+          <input
+            className='flex-grow min-w-60 text-sm px-2 py-2 focus-visible:outline-none border-none'
+            onBlur={handleAddInput}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                handleAddInput();
+              }
+            }}
+            onChange={(e) => {
+              setInput((prev) => ({
+                ...prev,
+                inputDraft: e.target.value.trim(),
+              }));
+            }}
+            value={inputDraft}
+            placeholder={placeholder}
+          />
+          <Dropdown
+            value={operator.toUpperCase()}
+            items={[
+              {
+                label: 'AND',
+                onClick: () => setOperator('and'),
+              },
+              {
+                label: 'OR',
+                onClick: () => setOperator('or'),
+              },
+            ].filter((item) => allowedOperator.includes(item.label.toLowerCase() as 'and' | 'or'))}
+          />
+        </span>
       </div>
     </div>
   );

--- a/src/modules/files/pages/files.tsx
+++ b/src/modules/files/pages/files.tsx
@@ -93,7 +93,7 @@ export default function FilesPage() {
           inputDraft={portalRunIdInput.inputDraft}
           setInput={setPortalRunIdInput}
           placeholder='Enter matching portal run id'
-          badgeType={getBadgeType}
+          badgeType={() => 'success'}
           operator={portalRunIdInput.operator}
           setOperator={(operator) => setPortalRunIdInput((prev) => ({ ...prev, operator }))}
           allowedOperator={['or']}
@@ -106,7 +106,7 @@ export default function FilesPage() {
           inputDraft={bucketInput.inputDraft}
           setInput={setBucketInput}
           placeholder='Enter matching bucket'
-          badgeType={getBadgeType}
+          badgeType={() => 'warning'}
           operator={bucketInput.operator}
           setOperator={(operator) => setBucketInput((prev) => ({ ...prev, operator }))}
           allowedOperator={['and', 'or']}

--- a/src/modules/files/pages/files.tsx
+++ b/src/modules/files/pages/files.tsx
@@ -3,10 +3,8 @@ import { Suspense, useState } from 'react';
 import { FileAPITable, getTableColumn } from '../components/FileAPITable';
 import { useQueryParams } from '@/hooks/useQueryParams';
 import { Badge } from '@/components/common/badges';
-import { XMarkIcon } from '@heroicons/react/16/solid';
 import { Button } from '@/components/common/buttons';
-import { InformationCircleIcon } from '@heroicons/react/24/outline';
-import { Tooltip } from '@/components/common/tooltips';
+import InputBadgeBox from '../components/InputBadgeBox';
 
 const WORKFLOW_FILTER = [
   '*/bclconvert-interop-qc/*',
@@ -43,129 +41,91 @@ const getBadgeType = (name: string) => {
   return 'unknown';
 };
 
+interface InputBadgeBoxType {
+  operator: 'and' | 'or';
+  inputState: string[];
+  inputDraft: string;
+}
+
 export default function FilesPage() {
   const { setQueryParams, getQueryParams } = useQueryParams();
-  const searchS3Key = getQueryParams().key as string | string[] | undefined;
-  const searchBucket = getQueryParams().bucket as string | string[] | undefined;
-  const [searchBucketInput, setSearchBucketInput] = useState<string[]>(
-    !searchBucket ? [] : Array.isArray(searchBucket) ? searchBucket : [searchBucket]
-  );
-  const [bucketCustomInputField, setBucketCustomInputField] = useState<string>('');
+  const s3KeyParam = getQueryParams().key as string | string[] | undefined;
+  const s3KeyOpParam = getQueryParams().keyOp as string | undefined;
 
-  const [searchS3KeyInput, setSearchS3KeyInput] = useState<string[]>(
-    !searchS3Key ? [] : Array.isArray(searchS3Key) ? searchS3Key : [searchS3Key]
-  );
-  const [s3KeyCustomInputField, setS3KeyCustomInputField] = useState<string>('');
+  const bucketParam = getQueryParams().bucket as string | string[] | undefined;
+  const bucketOpParam = getQueryParams().bucketOp as string | undefined;
 
-  const descKeyWidth = 'w-16';
+  const portalRunIdParam = getQueryParams().portalRunId as string | string[] | undefined;
+
+  // For PortalRunId
+  const [portalRunIdInput, setPortalRunIdInput] = useState<InputBadgeBoxType>({
+    operator: 'or',
+    inputState: !portalRunIdParam
+      ? []
+      : Array.isArray(portalRunIdParam)
+        ? portalRunIdParam
+        : [portalRunIdParam],
+    inputDraft: '',
+  });
+
+  // For S3 bucket
+  const [bucketInput, setBucketInput] = useState<InputBadgeBoxType>({
+    operator: 'or',
+    inputState: !bucketParam ? [] : Array.isArray(bucketParam) ? bucketParam : [bucketParam],
+    inputDraft: '',
+  });
+
+  // For S3 key
+  const [s3KeyInput, setS3KeyInput] = useState<InputBadgeBoxType>({
+    operator: 'and',
+    inputState: !s3KeyParam ? [] : Array.isArray(s3KeyParam) ? s3KeyParam : [s3KeyParam],
+    inputDraft: '',
+  });
+
   return (
     <div className='flex flex-col'>
       <h1 className='mb-4 font-bold'>File Browser</h1>
       <div className='flex flex-col'>
+        {/* PortalRunId */}
+        <InputBadgeBox
+          label='Portal Run Id'
+          inputState={portalRunIdInput.inputState}
+          inputDraft={portalRunIdInput.inputDraft}
+          setInput={setPortalRunIdInput}
+          placeholder='Enter matching portal run id'
+          badgeType={getBadgeType}
+          operator={portalRunIdInput.operator}
+          setOperator={(operator) => setPortalRunIdInput((prev) => ({ ...prev, operator }))}
+          allowedOperator={['or']}
+        />
+
         {/* Bucket */}
-        <div className='flex flex-row items-center'>
-          <div className={`${descKeyWidth} text-sm flex flex-row`}>Bucket</div>
-          <div className='rounded-lg w-full border py-1 px-1 flex flex-wrap'>
-            {searchBucketInput.map((key, index) => (
-              <Badge className='mx-1 my-1' key={`key-filter-${index}`} type='warning'>
-                {key}
-                <div className='pl-2 '>
-                  <XMarkIcon />
-                </div>
-                <div
-                  className='inline cursor-pointer'
-                  onClick={() => {
-                    setSearchBucketInput((prv) => prv.filter((val) => val !== key));
-                  }}
-                >
-                  <XMarkIcon aria-hidden='true' className='h-3 w-3' />
-                </div>
-              </Badge>
-            ))}
-            <input
-              className='flex-grow min-w-60 text-sm px-2 py-2 focus-visible:outline-none border-none'
-              onBlur={() => {
-                if (bucketCustomInputField && !searchBucketInput.includes(bucketCustomInputField)) {
-                  setSearchBucketInput((prv) => [...prv, bucketCustomInputField]);
-                }
-                setBucketCustomInputField('');
-              }}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  if (!searchBucketInput.includes(bucketCustomInputField)) {
-                    setSearchBucketInput((prv) => [...prv, bucketCustomInputField]);
-                  }
-                  setBucketCustomInputField('');
-                }
-              }}
-              onChange={(e) => {
-                setBucketCustomInputField(e.target.value.trim());
-              }}
-              value={bucketCustomInputField}
-              id='search'
-              name='search'
-              placeholder={'Enter matching bucket'}
-              type='search'
-            />
-          </div>
-        </div>
+        <InputBadgeBox
+          label='Bucket'
+          inputState={bucketInput.inputState}
+          inputDraft={bucketInput.inputDraft}
+          setInput={setBucketInput}
+          placeholder='Enter matching bucket'
+          badgeType={getBadgeType}
+          operator={bucketInput.operator}
+          setOperator={(operator) => setBucketInput((prev) => ({ ...prev, operator }))}
+          allowedOperator={['and', 'or']}
+        />
 
         {/* S3 Key */}
-        <div className='flex flex-row items-center mt-2'>
-          <div className={`${descKeyWidth} text-sm flex flex-row`}>
-            Key
-            <Tooltip
-              text={`The search matches values within S3 keys. Use an asterisk (*) as a wildcard to match any sequence of characters. For example, to search based on a portalRunId folder, use '*/123456/*'. Some shortcut filters are provided below.`}
-              position='right'
-              background='white'
-            >
-              <InformationCircleIcon className='mx-2 h-5 2-5' />
-            </Tooltip>
-          </div>
-          <div className='rounded-lg w-full border py-1 px-1 flex flex-wrap'>
-            {searchS3KeyInput.map((key, index) => (
-              <Badge className='mx-1 my-1' key={`key-filter-${index}`} type={getBadgeType(key)}>
-                {key}
-                <div className='pl-2 '>
-                  <XMarkIcon />
-                </div>
-                <div
-                  className='inline cursor-pointer'
-                  onClick={() => {
-                    setSearchS3KeyInput((prv) => prv.filter((val) => val !== key));
-                  }}
-                >
-                  <XMarkIcon aria-hidden='true' className='h-3 w-3' />
-                </div>
-              </Badge>
-            ))}
-            <input
-              className='flex-grow min-w-60 text-sm px-2 py-2 focus-visible:outline-none border-none'
-              onBlur={() => {
-                if (s3KeyCustomInputField && !searchS3KeyInput.includes(s3KeyCustomInputField)) {
-                  setSearchS3KeyInput((prv) => [...prv, s3KeyCustomInputField]);
-                }
-                setS3KeyCustomInputField('');
-              }}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  if (!searchS3KeyInput.includes(s3KeyCustomInputField)) {
-                    setSearchS3KeyInput((prv) => [...prv, s3KeyCustomInputField]);
-                  }
-                  setS3KeyCustomInputField('');
-                }
-              }}
-              onChange={(e) => {
-                setS3KeyCustomInputField(e.target.value.trim());
-              }}
-              value={s3KeyCustomInputField}
-              id='search'
-              name='search'
-              placeholder={'Enter S3 key pattern (wildcard supported)'}
-              type='search'
-            />
-          </div>
-        </div>
+        <InputBadgeBox
+          label='Key'
+          tooltipText={`The search matches values within S3 keys. Use an asterisk (*) as a wildcard to match any sequence of characters. For example, to search based on a portalRunId folder, use '*/123456/*'. Some shortcut filters are provided below.`}
+          inputState={s3KeyInput.inputState}
+          inputDraft={s3KeyInput.inputDraft}
+          setInput={setS3KeyInput}
+          placeholder='Enter S3 key pattern (wildcard supported)'
+          badgeType={getBadgeType}
+          operator={s3KeyInput.operator}
+          setOperator={(operator) => setS3KeyInput((prev) => ({ ...prev, operator }))}
+          allowedOperator={['and', 'or']}
+        />
+
         {/* Shortcut filter */}
         <div className='my-2'>
           {[...WORKFLOW_FILTER, ...FILE_TYPE_FILTER].map((name, idx) => (
@@ -173,10 +133,11 @@ export default function FilesPage() {
               className='inline cursor-pointer'
               key={`key-add-filter-${idx}`}
               onClick={() => {
-                if (!searchS3KeyInput.includes(name)) {
-                  setSearchS3KeyInput((prv) => {
-                    return [...prv, name];
-                  });
+                if (!s3KeyInput['inputState'].includes(name)) {
+                  setS3KeyInput((prv) => ({
+                    ...prv,
+                    inputState: [...prv['inputState'], name],
+                  }));
                 }
               }}
             >
@@ -190,8 +151,22 @@ export default function FilesPage() {
           <Button
             onClick={() => {
               setQueryParams({ key: [], bucket: [] });
-              setSearchS3KeyInput([]);
-              setS3KeyCustomInputField('');
+
+              setS3KeyInput((prv) => ({
+                ...prv,
+                inputState: [],
+                inputDraft: '',
+              }));
+              setBucketInput((prv) => ({
+                ...prv,
+                inputState: [],
+                inputDraft: '',
+              }));
+              setPortalRunIdInput((prv) => ({
+                ...prv,
+                inputState: [],
+                inputDraft: '',
+              }));
             }}
             className='mr-3 border'
             type='gray'
@@ -200,7 +175,13 @@ export default function FilesPage() {
           </Button>
           <Button
             onClick={() => {
-              setQueryParams({ key: searchS3KeyInput, bucket: searchBucketInput });
+              setQueryParams({
+                key: s3KeyInput['inputState'],
+                keyOp: s3KeyInput['operator'],
+                bucket: bucketInput['inputState'],
+                bucketOp: bucketInput['operator'],
+                portalRunId: portalRunIdInput['inputState'],
+              });
             }}
             type='green'
           >
@@ -208,14 +189,14 @@ export default function FilesPage() {
           </Button>
         </div>
       </div>
-
-      {/* Only show the table if the key filter exist! */}
-      {searchS3Key && (
+      {/* Only show the table if the key or portalRunId filter exist! */}
+      {(s3KeyParam || portalRunIdParam) && (
         <Suspense fallback={<SpinnerWithText className='mt-4' text='Fetching related files ...' />}>
           <FileAPITable
             additionalQueryParam={{
-              'key[]': searchS3Key,
-              'bucket[]': searchBucket,
+              [`key[${s3KeyOpParam ?? s3KeyInput['operator']}][]`]: s3KeyParam,
+              [`bucket[${bucketOpParam ?? bucketInput['operator']}][]`]: bucketParam,
+              [`attributes[portalRunId][]`]: portalRunIdParam,
             }}
             tableColumn={getTableColumn({ isHideKeyPrefix: false })}
           />

--- a/src/modules/lab/components/library/LibraryTableFilter.tsx
+++ b/src/modules/lab/components/library/LibraryTableFilter.tsx
@@ -6,7 +6,7 @@ import type { PhenotypeEnum, QualityEnum, TypeEnum, WorkflowEnum } from '@/api/m
 import { Button } from '@/components/common/buttons';
 import { FunnelIcon } from '@heroicons/react/24/outline';
 import { classNames } from '@/utils/commonUtils';
-import { FilterTextInput } from '../utils';
+import { FilterTextInput, CheckboxGroupInput } from '../utils';
 
 type FilterType = {
   orcabusId?: string[];
@@ -14,7 +14,7 @@ type FilterType = {
   assay?: string[];
   'coverage[gte]'?: string;
   'coverage[lte]'?: string;
-  project_id?: string[];
+  projectId?: string[];
   phenotype?: PhenotypeEnum[];
   quality?: QualityEnum[];
   type?: TypeEnum[];
@@ -100,8 +100,8 @@ export const LibraryTableFilter = () => {
       />
       <FilterTextInput
         title='Project Id *'
-        keyFilter='project_id'
-        defaultInput={filter.project_id ? filter.project_id : []}
+        keyFilter='projectId'
+        defaultInput={filter.projectId ? filter.projectId : []}
         handleFilterChange={handleFilterChange}
       />
 
@@ -114,28 +114,28 @@ export const LibraryTableFilter = () => {
         defaultMinInput={filter['coverage[gte]'] ? parseInt(filter['coverage[gte]']) : undefined}
       />
 
-      <CheckboxGroup
+      <CheckboxGroupInput
         title='Phenotype'
         keyFilter='phenotype'
         options={PHENOTYPE_OPTION}
         handleIsCheckedFunc={handleIsCheckedFunc}
         isCheckedFunc={isCheckedFilterActive}
       />
-      <CheckboxGroup
+      <CheckboxGroupInput
         title='Quality'
         keyFilter='quality'
         options={QUALITY_OPTION}
         handleIsCheckedFunc={handleIsCheckedFunc}
         isCheckedFunc={isCheckedFilterActive}
       />
-      <CheckboxGroup
+      <CheckboxGroupInput
         title='Type'
         keyFilter='type'
         options={TYPE_OPTION}
         handleIsCheckedFunc={handleIsCheckedFunc}
         isCheckedFunc={isCheckedFilterActive}
       />
-      <CheckboxGroup
+      <CheckboxGroupInput
         title='Workflow'
         keyFilter='workflow'
         options={WORKFLOW_OPTION}
@@ -254,45 +254,6 @@ const CoverageFilter = ({
           className='my-2 bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500/50 focus:border-blue-500/50 block w-full p-2.5'
         />
       </div>
-    </>
-  );
-};
-
-const CheckboxGroup = ({
-  title,
-  keyFilter,
-  options,
-  handleIsCheckedFunc,
-  isCheckedFunc,
-}: {
-  title: string;
-  keyFilter: keyof FilterType;
-  options: string[];
-  handleIsCheckedFunc: (key: keyof FilterType, value: string) => void;
-  isCheckedFunc: (key: keyof FilterType, value: string) => boolean;
-}) => {
-  return (
-    <>
-      <div className='font-medium'>{title}</div>
-      {options.map((item, key) => (
-        <div
-          key={`${keyFilter}-${key}`}
-          className='flex items-center ps-2 rounded hover:bg-gray-100 cursor-pointer'
-          onClick={() => {
-            handleIsCheckedFunc(keyFilter, item);
-          }}
-        >
-          <input
-            readOnly
-            checked={isCheckedFunc(keyFilter, item)}
-            type='checkbox'
-            className='w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500/50 focus:ring-2 cursor-pointer'
-          />
-          <label className='w-full py-2 ms-2 text-sm font-normal text-gray-900 rounded cursor-pointer'>
-            {item}
-          </label>
-        </div>
-      ))}
     </>
   );
 };

--- a/src/modules/lab/components/sample/SampleTableFilter.tsx
+++ b/src/modules/lab/components/sample/SampleTableFilter.tsx
@@ -11,6 +11,7 @@ type FilterType = {
   sampleId?: string[];
   externalSampleId?: string[];
   source?: string[];
+  isLibraryNone?: boolean;
 };
 
 export const SampleTableFilter = () => {
@@ -27,7 +28,7 @@ export const SampleTableFilter = () => {
     setFilter((prev) => ({ ...prev, [key]: value }));
   };
 
-  const IndividualFilter = () => (
+  const SampleFilter = () => (
     <>
       <FilterTextInput
         title='Orcabus Id *'
@@ -73,7 +74,24 @@ export const SampleTableFilter = () => {
       content={
         <div className='z-10 bg-white rounded-lg w-80'>
           <div className='max-h-[250px] px-3 pb-3 overflow-y-auto text-sm text-gray-700 '>
-            <IndividualFilter />
+            <SampleFilter />
+            <div className='font-medium'>{`Library`}</div>
+            <div
+              className='flex items-center ps-2 rounded hover:bg-gray-100 cursor-pointer'
+              onClick={() => {
+                setFilter((prev) => ({ ...prev, isLibraryNone: !prev['isLibraryNone'] }));
+              }}
+            >
+              <input
+                readOnly
+                checked={filter['isLibraryNone']}
+                type='checkbox'
+                className='w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500/50 focus:ring-2 cursor-pointer'
+              />
+              <label className='w-full py-2 ms-2 text-sm font-normal text-gray-900 rounded cursor-pointer'>
+                Empty library
+              </label>
+            </div>
           </div>
           <ClosePopoverWrapper className='mt-4'>
             <Button

--- a/src/modules/lab/components/subject/SubjectListAPITable.tsx
+++ b/src/modules/lab/components/subject/SubjectListAPITable.tsx
@@ -130,7 +130,7 @@ export const individualTableColumn = (): Column[] => {
       header: (
         <div className='flex flex-row items-center'>
           <div>Individual Id</div>
-          <Tooltip text={`This is now the 'SubjectID' from the tracking sheet`} position='top'>
+          <Tooltip text={`This is now the 'SubjectID' from the tracking sheet`} position='right'>
             <InformationCircleIcon className='h-4	ml-2' />
           </Tooltip>
         </div>

--- a/src/modules/lab/components/subject/SubjectTableFilter.tsx
+++ b/src/modules/lab/components/subject/SubjectTableFilter.tsx
@@ -9,6 +9,7 @@ import { FilterTextInput } from '../utils';
 type FilterType = {
   orcabusId?: string[];
   subjectId?: string[];
+  isLibraryNone?: boolean;
 };
 
 export const SubjectTableFilter = () => {
@@ -60,6 +61,24 @@ export const SubjectTableFilter = () => {
         <div className='z-10 bg-white rounded-lg w-80'>
           <div className='max-h-[250px] px-3 pb-3 overflow-y-auto text-sm text-gray-700 '>
             <SubjectFilter />
+
+            <div className='font-medium'>{`Library`}</div>
+            <div
+              className='flex items-center ps-2 rounded hover:bg-gray-100 cursor-pointer'
+              onClick={() => {
+                setFilter((prev) => ({ ...prev, isLibraryNone: !prev['isLibraryNone'] }));
+              }}
+            >
+              <input
+                readOnly
+                checked={filter['isLibraryNone']}
+                type='checkbox'
+                className='w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500/50 focus:ring-2 cursor-pointer'
+              />
+              <label className='w-full py-2 ms-2 text-sm font-normal text-gray-900 rounded cursor-pointer'>
+                Empty library
+              </label>
+            </div>
           </div>
           <ClosePopoverWrapper className='mt-4'>
             <Button

--- a/src/modules/lab/components/subject/utils.tsx
+++ b/src/modules/lab/components/subject/utils.tsx
@@ -24,7 +24,7 @@ export const getSubjectTableColumn = ({
         <div>Subject Id</div>
         <Tooltip
           text={`This is now the 'ExternalSubjectID' from the tracking sheet`}
-          position='top'
+          position='right'
         >
           <InformationCircleIcon className='h-4	ml-2' />
         </Tooltip>

--- a/src/modules/lab/components/utils.tsx
+++ b/src/modules/lab/components/utils.tsx
@@ -45,3 +45,43 @@ export const FilterTextInput = <T,>({
     </>
   );
 };
+
+interface CheckboxGroupInputProps<T> {
+  title?: string;
+  keyFilter: keyof T;
+  options: string[];
+  handleIsCheckedFunc: (key: keyof T, value: string) => void;
+  isCheckedFunc: (key: keyof T, value: string) => boolean;
+}
+export const CheckboxGroupInput = <T,>({
+  title,
+  keyFilter,
+  options,
+  handleIsCheckedFunc,
+  isCheckedFunc,
+}: CheckboxGroupInputProps<T>) => {
+  return (
+    <>
+      {title && <div className='font-medium'>{title}</div>}
+      {options.map((item, key) => (
+        <div
+          key={`${title}-${key}`}
+          className='flex items-center ps-2 rounded hover:bg-gray-100 cursor-pointer'
+          onClick={() => {
+            handleIsCheckedFunc(keyFilter, item);
+          }}
+        >
+          <input
+            readOnly
+            checked={isCheckedFunc(keyFilter, item)}
+            type='checkbox'
+            className='w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500/50 focus:ring-2 cursor-pointer'
+          />
+          <label className='w-full py-2 ms-2 text-sm font-normal text-gray-900 rounded cursor-pointer'>
+            {item}
+          </label>
+        </div>
+      ))}
+    </>
+  );
+};


### PR DESCRIPTION
-  Add to filter the library-less Sample/Subject (Related https://github.com/umccr/orcabus/pull/765)
- Extend the file filtering process for multi-query params between `or` or `and` on FM (Related https://github.com/umccr/orcabus/pull/762)

<img width="875" alt="Screenshot 2024-12-10 at 18 30 53" src="https://github.com/user-attachments/assets/82a85b08-a934-41b6-97e8-1a9cc0a437e8">


Related #90 

