### PR TITLE
Fix: Lab Library Layout

### DIFF
--- a/src/components/layouts/lab/components/LibrarySideNavBar.tsx
+++ b/src/components/layouts/lab/components/LibrarySideNavBar.tsx
@@ -45,7 +45,9 @@ export const LibrarySideNavBar = () => {
                 // We wanted to know if the workflow name is selected in the NavBar
                 isCurrent: portalRunId
                   ? pathname.split(portalRunId)[0].endsWith(`${wf.workflowName}/`)
-                  : undefined,
+                  : // In case trailing slash in pathname
+                    pathname.endsWith(`${wf.workflowName}/`) ||
+                    pathname.endsWith(`${wf.workflowName}`),
               }))
               // Filter out duplicate workflows
               .filter((wf) => {

--- a/src/components/navigation/navbar/ModuleNavBar.tsx
+++ b/src/components/navigation/navbar/ModuleNavBar.tsx
@@ -7,6 +7,7 @@ import { Bars3Icon } from '@heroicons/react/24/outline';
 export interface NavigationChildrenItem {
   name: string;
   href: string;
+  isCurrent?: boolean;
 }
 
 export interface NavigationItem {
@@ -51,19 +52,22 @@ const ModuleNavbar: FC<ModuleNavbarProps> = ({ navigation, footer }) => {
                     <div className='pb-3'></div>
                   )}
 
-                  {item.children.map((item) => (
-                    <div key={item.name} className='py-1'>
-                      <Link
-                        to={item.href}
-                        className={classNames(
-                          'group flex py-2 px-10 text-sm rounded-md leading-6 font-normal text-magpie-dark-75 hover:bg-magpie-light-50',
-                          location.pathname.includes(item.href) ? 'bg-magpie-light-50' : ''
-                        )}
-                      >
-                        {item.name}
-                      </Link>
-                    </div>
-                  ))}
+                  {item.children.map((item) => {
+                    const isSelected = item.isCurrent ?? location.pathname.includes(item.href);
+                    return (
+                      <div key={item.name} className='py-1'>
+                        <Link
+                          to={item.href}
+                          className={classNames(
+                            'group flex py-2 px-10 text-sm rounded-md leading-6 font-normal text-magpie-dark-75 hover:bg-magpie-light-50',
+                            isSelected ? 'bg-magpie-light-50' : ''
+                          )}
+                        >
+                          {item.name}
+                        </Link>
+                      </div>
+                    );
+                  })}
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
The default path detection (using `includes`) for the current might end up selecting multiple tabs.


<img width="302" alt="Screenshot 2025-02-03 at 10 21 36" src="https://github.com/user-attachments/assets/f2eb9abb-93c7-4963-9a7d-45b341cff1a5" />
