### PR TITLE
Refactor:  Library Overview Page

### DIFF
--- a/src/components/common/json-to-table/json-to-table.tsx
+++ b/src/components/common/json-to-table/json-to-table.tsx
@@ -2,10 +2,10 @@
 import React from 'react';
 
 const JsonToTable = ({ data }: { data: Record<string, any> }) => {
-  const keyClassName = 'font-medium px-4 py-3 text-sm text-gray-700 dark:text-gray-300';
+  const keyClassName = 'font-bold px-4 py-3 text-sm text-gray-700 dark:text-gray-300';
   const valueClassName = 'px-4 py-3 text-sm text-gray-600 dark:text-gray-400';
   const rowClassName =
-    'border-b border-gray-100 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors';
+    'border-b border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors';
 
   const renderValue = (value: any) => {
     if (!value) {

--- a/src/components/common/sidebar/SideBar.tsx
+++ b/src/components/common/sidebar/SideBar.tsx
@@ -1,0 +1,65 @@
+import React, { FC, ReactNode, useState } from 'react';
+import {
+  ArrowLeftStartOnRectangleIcon,
+  ArrowRightStartOnRectangleIcon,
+} from '@heroicons/react/16/solid';
+import { classNames } from '@/utils/commonUtils';
+
+export interface SidebarProps {
+  position: 'left' | 'right';
+  title?: string;
+  children: ReactNode;
+  footer?: ReactNode;
+}
+
+const Sidebar: FC<SidebarProps> = ({ title, children, footer, position }) => {
+  const [isOpen, setIsOpen] = useState(true);
+  return (
+    <div
+      className={classNames(
+        'group relative flex h-full flex-col border-r border-gray-300 transition-all duration-300 dark:border-gray-700',
+        isOpen ? 'w-96' : 'w-16',
+        position === 'left' ? 'border-r' : 'border-l',
+        position === 'left' ? 'left-0' : 'right-0'
+      )}
+    >
+      {isOpen ? (
+        <>
+          <div className={`absolute ${position === 'left' ? 'right' : 'left'}-0 top-0 z-20 p-4`}>
+            <button
+              type='button'
+              onClick={() => setIsOpen(false)}
+              className='rounded-lg bg-gray-50 p-1.5 text-gray-400 ring-1 ring-gray-200 hover:bg-gray-100 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:ring-offset-2 dark:bg-gray-700 dark:ring-gray-600 dark:hover:bg-gray-600 dark:hover:text-gray-300'
+            >
+              <span className='sr-only'>Close sidebar</span>
+              <ArrowRightStartOnRectangleIcon className='h-5 w-5' />
+            </button>
+          </div>
+
+          {title && (
+            <div className='sticky top-0 z-10 border-b border-inherit px-6 py-4'>
+              <h2 className='text-xl font-semibold text-gray-900 dark:text-white'>{title ?? ''}</h2>
+            </div>
+          )}
+
+          <div className='flex-1 space-y-2 px-3 py-2'>{children}</div>
+
+          {footer && <div className='px-3 py-2'>{footer}</div>}
+        </>
+      ) : (
+        <div className={`absolute ${position === 'left' ? 'right' : 'left'}-0 top-0 z-20 p-3`}>
+          <button
+            type='button'
+            onClick={() => setIsOpen(true)}
+            className='rounded-md p-2 text-gray-400 hover:bg-gray-100 hover:text-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500/50 focus:ring-offset-2 dark:hover:bg-gray-700 dark:hover:text-gray-300'
+          >
+            <span className='sr-only'>Open sidebar</span>
+            <ArrowLeftStartOnRectangleIcon className='h-5 w-5' />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default Sidebar;

--- a/src/components/common/sidebar/SideBarLayout.tsx
+++ b/src/components/common/sidebar/SideBarLayout.tsx
@@ -1,0 +1,19 @@
+import React, { FC, ReactNode } from 'react';
+
+export interface SidebarProps {
+  main: ReactNode;
+  sideBar: ReactNode;
+  sideBarPosition: 'left' | 'right';
+}
+
+const SidebarLayout: FC<SidebarProps> = ({ main, sideBar, sideBarPosition }) => {
+  return (
+    <div className='flex h-full flex-row'>
+      {sideBarPosition === 'left' && <div className='flex h-full'>{sideBar}</div>}
+      <div className='w-full'>{main}</div>
+      {sideBarPosition === 'right' && <div className='flex h-full'>{sideBar}</div>}
+    </div>
+  );
+};
+
+export default SidebarLayout;

--- a/src/components/common/sidebar/index.tsx
+++ b/src/components/common/sidebar/index.tsx
@@ -1,0 +1,4 @@
+import Sidebar from './SideBar';
+import SideBarLayout from './SideBarLayout';
+
+export { Sidebar, SideBarLayout };

--- a/src/components/layouts/lab/LibraryLayout.tsx
+++ b/src/components/layouts/lab/LibraryLayout.tsx
@@ -4,9 +4,8 @@ import { Outlet } from 'react-router-dom';
 import { SpinnerWithText } from '@/components/common/spinner';
 import { DetailedErrorBoundary } from '@/components/common/error';
 import { LibrarySideNavBar } from './components/LibrarySideNavBar';
-// import { LibraryBreadCrumb } from './components/LibraryBreadCrumb';
 import LocationBreadcrumb from '@/components/navigation/breadcrumbs';
-// import { Dropdown } from '@/components/common/dropdowns';
+import { LibraryDetailBar } from './components/LibraryDetailBar';
 
 const LibraryLayout = ({ children }: PropsWithChildren) => {
   return (
@@ -18,17 +17,15 @@ const LibraryLayout = ({ children }: PropsWithChildren) => {
         <div className='flex min-w-[450px] flex-1 flex-col overflow-auto overflow-x-auto px-8 py-4'>
           <LocationBreadcrumb />
 
-          {/* Will comment library versioning for now */}
-          {/* <div className='flex flex-row justify-between space-x-4'>
-            <LibraryBreadCrumb />
-            <Dropdown className='' items={[{ label: 'RESEARCH' }]} value='RESEARCH' />
-          </div> */}
-
+          {/* <LibraryBreadCrumb /> */}
           <Suspense fallback={<SpinnerWithText text='Loading library page' />}>
             <DetailedErrorBoundary errorTitle='Unable to load library page'>
               {children || <Outlet />}
             </DetailedErrorBoundary>
           </Suspense>
+        </div>
+        <div className='flex h-full'>
+          <LibraryDetailBar />
         </div>
       </div>
     </Suspense>

--- a/src/components/layouts/lab/components/LibraryDetailBar.tsx
+++ b/src/components/layouts/lab/components/LibraryDetailBar.tsx
@@ -1,8 +1,9 @@
 import { useParams } from 'react-router-dom';
-import { LibraryAnalysisReportTable } from '../../components/library/LibraryAnalysisReportTable';
+import { Sidebar } from '@/components/common/sidebar';
 import { useSuspenseMetadataDetailLibraryModel } from '@/api/metadata';
+import { LibraryTableDetails } from '@/modules/lab/components/library/LibraryTableDetails';
 
-export default function LibraryOverviewPage() {
+export const LibraryDetailBar = () => {
   const { libraryOrcabusId } = useParams();
   if (!libraryOrcabusId) {
     throw new Error('No library id in URL path!');
@@ -19,9 +20,12 @@ export default function LibraryOverviewPage() {
   if (!libraryDetailRes) {
     throw new Error('No library Id found in metadata!');
   }
+
   return (
-    <div className='w-full'>
-      <LibraryAnalysisReportTable libraryDetail={libraryDetailRes} />
-    </div>
+    <Sidebar position='right'>
+      <div className='mt-20'>
+        <LibraryTableDetails libraryDetail={libraryDetailRes} />
+      </div>
+    </Sidebar>
   );
-}
+};

--- a/src/components/layouts/lab/components/LibrarySideNavBar.tsx
+++ b/src/components/layouts/lab/components/LibrarySideNavBar.tsx
@@ -3,6 +3,7 @@ import { useLocation, useParams } from 'react-router-dom';
 import { useSuspenseWorkflowModel } from '@/api/workflow';
 import { DEFAULT_NON_PAGINATE_PAGE_SIZE } from '@/utils/constant';
 import { HomeIcon, ClockIcon } from '@heroicons/react/24/outline';
+import { WorkflowIcon } from '@/components/icons/WorkflowIcon';
 // import { getWorkflowIcon } from '@/utils/workflows';
 
 export const LibrarySideNavBar = () => {
@@ -37,6 +38,11 @@ export const LibrarySideNavBar = () => {
               name: 'Overview',
               href: `${baseHref}/overview`,
               icon: HomeIcon,
+            },
+            {
+              name: 'Workflow Runs',
+              href: `${baseHref}/workflow-runs`,
+              icon: WorkflowIcon,
             },
             {
               name: 'History',

--- a/src/components/navigation/breadcrumbs/index.tsx
+++ b/src/components/navigation/breadcrumbs/index.tsx
@@ -3,14 +3,6 @@ import { classNames } from '@/utils/commonUtils';
 import { FC } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 
-// export type BreadcrumbProps = {
-//   pages: {
-//     name: string;
-//     href: string;
-//     current: boolean;
-//   }[];
-// };
-
 const LocationBreadcrumb: FC = () => {
   // const { pages } = props;
 

--- a/src/modules/lab/components/library/LibraryAnalysisReportTable.tsx
+++ b/src/modules/lab/components/library/LibraryAnalysisReportTable.tsx
@@ -12,7 +12,8 @@ import { DEFAULT_NON_PAGINATE_PAGE_SIZE } from '@/utils/constant';
 import { SpinnerWithText } from '@/components/common/spinner';
 import { Link } from 'react-router-dom';
 import { classNames } from '@/utils/commonUtils';
-import { DocumentMagnifyingGlassIcon } from '@heroicons/react/24/outline';
+import { ExclamationTriangleIcon } from '@heroicons/react/24/outline';
+import { Badge } from '@/components/common/badges';
 
 const WORKFLOW_ANALYSIS_TABLE = {
   umccrise: {
@@ -142,7 +143,7 @@ export const LibraryAnalysisReportTable: FC<LibraryAnalysisReportTableProps> = (
 
   return (
     <Suspense fallback={<SpinnerWithText text='loading data ...' />}>
-      <div className='py-3 text-lg font-bold'>Workflow Results</div>
+      <div className='py-3 text-lg font-bold'>Overview Highlights</div>
       {libraryDetail.type === 'WGS' ? (
         <>
           <DetailedErrorBoundary errorTitle={`Unable to load 'umccrise' report files`}>
@@ -252,30 +253,43 @@ export const AnalysisTable = ({
     fileRecord: item,
   }));
 
+  const isMultipleRuns = workflowRunResults.length > 1;
+
   return (
     <>
       <GroupedTable
         tableHeader={
           <div className='flex flex-row items-center justify-between'>
-            <div>{workflowType}</div>
             <div className='flex flex-row'>
+              <div>{workflowType}</div>
               <Link
                 to={`/runs/workflow?search=${portalRunId}`}
-                className={classNames('mt-4 text-sm font-medium hover:text-blue-700')}
+                className={classNames(
+                  'flex items-center text-sm font-medium text-blue-500 underline hover:text-blue-700'
+                )}
               >
-                <div className='mr-4 items-center'>
-                  <DocumentMagnifyingGlassIcon className='h-5 w-5' />
+                <div className='ml-6 items-center'>
+                  {portalRunId}
+                  {/* <DocumentMagnifyingGlassIcon className='h-5 w-5' /> */}
                 </div>
               </Link>
-              <Dropdown
-                floatingLabel='Portal Run Id'
-                value={portalRunId}
-                items={workflowRunResults.map((i) => ({
-                  label: i.portalRunId,
-                  onClick: () => setSelectedPortalRunId(i.portalRunId),
-                }))}
-              />
             </div>
+            {isMultipleRuns && (
+              <div className='flex flex-row'>
+                <Badge type='warning' className='mr-2'>
+                  <ExclamationTriangleIcon className='mr-2 h-5 w-5' />
+                  Multiple runs
+                </Badge>
+                <Dropdown
+                  floatingLabel='Portal Run Id'
+                  value={portalRunId}
+                  items={workflowRunResults.map((i) => ({
+                    label: i.portalRunId,
+                    onClick: () => setSelectedPortalRunId(i.portalRunId),
+                  }))}
+                />
+              </div>
+            )}
           </div>
         }
         striped={false}

--- a/src/modules/lab/pages/library/LibraryWorkflowRuns.tsx
+++ b/src/modules/lab/pages/library/LibraryWorkflowRuns.tsx
@@ -1,8 +1,9 @@
 import { useParams } from 'react-router-dom';
-import { LibraryAnalysisReportTable } from '../../components/library/LibraryAnalysisReportTable';
 import { useSuspenseMetadataDetailLibraryModel } from '@/api/metadata';
+import WorkflowRunTable from '@/modules/runs/components/workflowRuns/WorkflowRunTable';
+import { classNames } from '@/utils/commonUtils';
 
-export default function LibraryOverviewPage() {
+export default function LibraryWorkflowRunsPage() {
   const { libraryOrcabusId } = useParams();
   if (!libraryOrcabusId) {
     throw new Error('No library id in URL path!');
@@ -21,7 +22,10 @@ export default function LibraryOverviewPage() {
   }
   return (
     <div className='w-full'>
-      <LibraryAnalysisReportTable libraryDetail={libraryDetailRes} />
+      <div className={classNames('my-4 ml-2 text-sm font-medium')}>
+        <div className='text-lg font-bold'>Workflow Run</div>
+      </div>
+      <WorkflowRunTable libraryOrcabusId={libraryOrcabusId} />
     </div>
   );
 }

--- a/src/modules/lab/routes.tsx
+++ b/src/modules/lab/routes.tsx
@@ -12,6 +12,9 @@ const SyncPage = lazy(() => import('@/modules/lab/pages/Sync'));
 const LibraryOverviewPage = lazy(() => import('@/modules/lab/pages/library/LibraryOverview'));
 const LibraryWorkflowPage = lazy(() => import('@/modules/lab/pages/library/LibraryWorkflow'));
 const LibraryHistoryPage = lazy(() => import('@/modules/lab/pages/library/LibraryHistory'));
+const LibraryWorkflowRunsPage = lazy(
+  () => import('@/modules/lab/pages/library/LibraryWorkflowRuns')
+);
 
 export const Router: RouteObject = {
   path: 'lab',
@@ -65,6 +68,10 @@ export const Router: RouteObject = {
             {
               path: 'overview',
               element: <LibraryOverviewPage />,
+            },
+            {
+              path: 'workflow-runs',
+              element: <LibraryWorkflowRunsPage />,
             },
             {
               path: 'history',


### PR DESCRIPTION
- Split workflow runs page to a dedicated page in a single Library Context
- Move Library details to sideBar
- Warning for multiple portal-run-id for same workflow type in the overview page


[demo](https://orcaui.dev.umccr.org/lab/library/lib.01JBB5Y31GBQHP4X90PZ28X14R/overview)

Related #119 