### PR TITLE
add user prefence local storage hooks for combined user preferences

### DIFF
--- a/src/components/common/sidebar/SideBar.tsx
+++ b/src/components/common/sidebar/SideBar.tsx
@@ -4,7 +4,7 @@ import {
   ArrowRightStartOnRectangleIcon,
 } from '@heroicons/react/16/solid';
 import { classNames } from '@/utils/commonUtils';
-import { useLocalStorage } from '@/hooks/useLocalStorage';
+import { useUserPreferencesLocalStorage } from '@/hooks/useLocalStorage';
 
 export interface SidebarProps {
   position: 'left' | 'right';
@@ -27,7 +27,10 @@ const Sidebar: FC<SidebarProps> = ({
   openWidth = 'w-92',
   collapsedWidth = 'w-16',
 }) => {
-  const [isOpen, setIsOpen] = useLocalStorage(preferenceStorageKey ?? 'sidebar-open', true);
+  const [isOpen, setIsOpen] = useUserPreferencesLocalStorage(
+    preferenceStorageKey ?? 'sidebar-open',
+    true
+  );
 
   return (
     <aside

--- a/src/components/navigation/navbar/ModuleNavBar.tsx
+++ b/src/components/navigation/navbar/ModuleNavBar.tsx
@@ -4,7 +4,7 @@ import { FC, useState, ReactNode, FunctionComponent, SVGProps } from 'react';
 import { XMarkIcon } from '@heroicons/react/16/solid';
 import { Bars3Icon } from '@heroicons/react/24/outline';
 import { Tooltip } from '@/components/common/tooltips';
-import { useLocalStorage } from '@/hooks/useLocalStorage';
+import { useUserPreferencesLocalStorage } from '@/hooks/useLocalStorage';
 
 export interface NavigationChildrenItem {
   name: string;
@@ -27,7 +27,7 @@ export interface ModuleNavbarProps {
 
 const ModuleNavbar: FC<ModuleNavbarProps> = ({ navigation, footer, preferenceStorageKey }) => {
   const location = useLocation();
-  const [isOpenNavbar, setIsOpenNavbar] = useLocalStorage(
+  const [isOpenNavbar, setIsOpenNavbar] = useUserPreferencesLocalStorage(
     preferenceStorageKey ?? 'isOpenNavbar',
     true
   );

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -2,7 +2,7 @@
 // https://github.com/ArnaudBarre/eslint-plugin-react-refresh/issues/25#issuecomment-1729071347
 
 import { createContext, useContext, useState, useEffect, PropsWithChildren } from 'react';
-import { useLocalStorage } from '../hooks/useLocalStorage';
+import { useUserPreferencesLocalStorage } from '../hooks/useLocalStorage';
 
 interface ThemeContextType {
   currentTheme: string;
@@ -19,7 +19,7 @@ export const useTheme = () => {
 };
 
 export const ThemeProvider = ({ children }: PropsWithChildren) => {
-  const [persistedTheme, setPersistedTheme] = useLocalStorage('theme', 'system');
+  const [persistedTheme, setPersistedTheme] = useUserPreferencesLocalStorage('theme', 'system');
   const [currentTheme, setCurrentTheme] = useState<string>(persistedTheme || 'system');
 
   const changeCurrentTheme = (newTheme: string) => {

--- a/src/modules/runs/components/sequenceRuns/SequenceRundetailsTimeline.tsx
+++ b/src/modules/runs/components/sequenceRuns/SequenceRundetailsTimeline.tsx
@@ -16,7 +16,7 @@ import CommentDialog from '../common/CommentDialog';
 import { useParams } from 'react-router-dom';
 import { Button } from '@/components/common/buttons';
 import { BarsArrowUpIcon, BarsArrowDownIcon } from '@heroicons/react/24/outline';
-import { useLocalStorage } from '@/hooks/useLocalStorage';
+import { useUserPreferencesLocalStorage } from '@/hooks/useLocalStorage';
 import StateDialog from '../common/StateDialog';
 import { useSequenceRunContext } from './SequenceRunContext';
 
@@ -51,7 +51,7 @@ const SequenceRunTimeline: FC<SequenceRunTimelineProps> = ({ selectedSequenceRun
   const [stateId, setStateId] = useState<string | null>(null);
   const [stateComment, setStateComment] = useState<string>('');
 
-  const [isReverseOrder, setIsReverseOrder] = useLocalStorage(
+  const [isReverseOrder, setIsReverseOrder] = useUserPreferencesLocalStorage(
     'sequence-run-timeline-reverse-order',
     false
   );

--- a/src/modules/runs/components/workflowRuns/WorkflowRunTimeline.tsx
+++ b/src/modules/runs/components/workflowRuns/WorkflowRunTimeline.tsx
@@ -31,7 +31,7 @@ import { Button } from '@/components/common/buttons';
 import CommentDialog from '../common/CommentDialog';
 import StateDialog from '../common/StateDialog';
 import { Accordion } from '@/components/common/accordion';
-import { useLocalStorage } from '@/hooks/useLocalStorage';
+import { useUserPreferencesLocalStorage } from '@/hooks/useLocalStorage';
 
 const WorkflowRunTimeline = () => {
   const { orcabusId } = useParams();
@@ -55,7 +55,7 @@ const WorkflowRunTimeline = () => {
   const [commentId, setCommentId] = useState<string | null>(null);
   const [comment, setComment] = useState<string>('');
 
-  const [isReverseOrder, setIsReverseOrder] = useLocalStorage(
+  const [isReverseOrder, setIsReverseOrder] = useUserPreferencesLocalStorage(
     'workflow-run-timeline-reverse-order',
     false
   );


### PR DESCRIPTION
add user prefence local storage hooks for combined user preferences in local storage. 
Example:
```{"theme":"system","expiration":null,"workflow-run-details-sidebar":false,"runs-module-navbar":false,"sequence-run-timeline-reverse-order":true,"workflow-run-timeline-reverse-order":false}```