### PR TITLE
Fix: Error Handling on File listing

### DIFF
--- a/src/components/common/error/ErrorBox.tsx
+++ b/src/components/common/error/ErrorBox.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+type Props = { message: string };
+
+export default function ErrorBox({ message }: Props) {
+  return (
+    <div className='rounded-md bg-red-50 p-4 dark:bg-red-900/10'>
+      <pre className='font-mono text-sm break-words whitespace-pre-wrap text-red-600 dark:text-red-400'>
+        {message}
+      </pre>
+    </div>
+  );
+}

--- a/src/modules/lab/pages/library/LibraryWorkflow.tsx
+++ b/src/modules/lab/pages/library/LibraryWorkflow.tsx
@@ -14,6 +14,7 @@ import { CursorArrowRaysIcon, InformationCircleIcon } from '@heroicons/react/24/
 import { areArraysEqual } from '@/modules/files/components/utils';
 import { Checkbox } from '@/components/common/checkbox';
 import { Tooltip } from '@/components/common/tooltips';
+import ErrorBox from '@/components/common/error/ErrorBox';
 
 interface KeyPatternType {
   label: string;
@@ -117,7 +118,7 @@ export default function LibraryWorkflowPage() {
 
   const workflowRunResults = workflowRun?.results;
   if (!workflowRunResults?.length) {
-    throw new Error('No workflow run found!');
+    return <ErrorBox message={'No workflow run found!'} />;
   }
   if (!portalRunId) {
     return <Navigate to={`${workflowRunResults[0].portalRunId}`} />;
@@ -126,7 +127,7 @@ export default function LibraryWorkflowPage() {
   // If portalRunId is not found in the list of workflowRun, it is invalid link
   const currentWorkflowRunDetail = workflowRunResults.find((i) => i.portalRunId === portalRunId);
   if (!currentWorkflowRunDetail) {
-    throw new Error('Invalid link!');
+    return <ErrorBox message={'Invalid link!'} />;
   }
 
   const isMultipleRuns = workflowRunResults.length > 1;


### PR DESCRIPTION
Ensure the return error component instead of an error boundary. To ensure component refresh when the path changes.

closes #207 