### PR TITLE
add PortalRedirect page for portalrunid redirect

### DIFF
--- a/src/modules/workflows/pages/WorkflowRunPortalRedirect.tsx
+++ b/src/modules/workflows/pages/WorkflowRunPortalRedirect.tsx
@@ -6,7 +6,7 @@ import { SpinnerWithText } from '@/components/common/spinner';
  * Resolves a portal run ID (used by external users) to the internal orcabusId
  * and redirects to the workflow run details page.
  *
- * External users should link to: /workflows/workflowRuns/portal/:portalRunId
+ * External users should link to: /workflows/workflowRuns/prid/:portalRunId
  * This page fetches the run by portalRunId and redirects to /workflows/workflowRuns/:orcabusId
  */
 const WorkflowRunPortalRedirect = () => {

--- a/src/modules/workflows/routes.tsx
+++ b/src/modules/workflows/routes.tsx
@@ -35,7 +35,7 @@ export const Router: RouteObject = {
       ],
     },
     {
-      path: 'workflowRuns/portal/:portalRunId',
+      path: 'workflowRuns/prid/:portalRunId',
       element: <WorkflowRunPortalRedirect />,
     },
     { path: 'workflowRuns/:orcabusId', element: <WorkflowRunsDetailsPage /> },


### PR DESCRIPTION
## Summary
External users only have Portal Run ID when linking to workflow runs from their services; they do not have our internal orcabusId. This PR adds a dedicated route so they can use Portal Run ID in the URL. The app resolves it to the corresponding workflow run and redirects to the canonical details URL.


## Changes
New route: `workflows/workflowRuns/prid/:portalRunId`

- Intended for external systems linking with Portal Run ID.
- Declared before `workflowRuns/:orcabusId` so "prid" is not treated as an orcabusId.

New page: **WorkflowRunPortalRedirect**

- Reads portalRunId from the URL.
- Calls the workflow run list API filtered by portal run ID, with order_by: '-timestamp' so the server returns the latest run first.
- Single match → redirects to workflows/workflowRuns/:orcabusId.
- No matches → shows a “Workflow run not found” message and a “Back to Workflow Runs” link.
- Multiple matches → redirects to the latest run (first result from the API). Emits a console warning with the portal run ID and the orcabusId being shown, and console.logs all matching runs for debugging.
- Shows a loading state while resolving.

Existing behavior unchanged.

URL for external users

`/workflows/workflowRuns/prid/{portalRunId}`


Test on DEV: [https://portal.dev.umccr.org/workflows/workflowRuns/prid/20260303dfa32dbe](https://portal.dev.umccr.org/workflows/workflowRuns/prid/20260303dfa32dbe)
