### PR TITLE
fix sequence timeline order lastest by default

### DIFF
--- a/src/modules/sequence/components/sequenceRuns/SequenceRunDetailsTimeline.tsx
+++ b/src/modules/sequence/components/sequenceRuns/SequenceRunDetailsTimeline.tsx
@@ -213,7 +213,7 @@ const SequenceRunDetailsTimeline: FC<SequenceRunDetailsTimelineProps> = ({
   }, [selectedSequenceRunComment]);
 
   const timelineData = [...SequenceRunStateTimelineData, ...SequenceRunCommentTimelineData].sort(
-    (a, b) => (dayjs(a.datetime).isBefore(dayjs(b.datetime)) ? -1 : 1)
+    (a, b) => (dayjs(a.datetime).isAfter(dayjs(b.datetime)) ? -1 : 1)
   );
 
   const {


### PR DESCRIPTION
Quick fix for sequence timeline order.
Resolve https://github.com/OrcaBus/orca-ui/issues/246