### PR TITLE
fix: stop infinite refetch loop and broken workflow run link on sequence run workflow runs tab

### DIFF
--- a/src/modules/sequence/components/sequenceRuns/SequenceRunWorkflowRuns.tsx
+++ b/src/modules/sequence/components/sequenceRuns/SequenceRunWorkflowRuns.tsx
@@ -1,4 +1,4 @@
-import { useSequenceRunContext } from './SequenceRunContext';
+import { useSequenceRunWorkflowRunFilter } from './useSequenceRunWorkflowRunFilter';
 import { useWorkflowRunListModel } from '@/api/workflow';
 import { useMemo } from 'react';
 import { Column, TableData, Table } from '@/components/tables';
@@ -12,18 +12,7 @@ import { useQueryParams } from '@/hooks/useQueryParams';
 const SequenceRunWorkflowRuns = () => {
   const { setQueryParams, getPaginationParams, getQueryParams } = useQueryParams();
 
-  const { sequenceRunDetail } = useSequenceRunContext();
-
-  // lastest run library ids
-  const libraryIds = sequenceRunDetail?.sort((a, b) => {
-    return dayjs(b.endTime).diff(dayjs(a.endTime));
-  })[0]?.libraries;
-
-  // time range (first run end time  to 2 days after)
-  const start_time = sequenceRunDetail?.sort((a, b) => {
-    return dayjs(a.endTime).diff(dayjs(b.endTime));
-  })[0]?.endTime;
-  const end_time = dayjs(start_time).add(2, 'days').toISOString();
+  const { libraryIds, start_time, end_time } = useSequenceRunWorkflowRunFilter();
 
   const { data: workflowRuns, isLoading: isLoadingWorkflowRuns } = useWorkflowRunListModel({
     params: {
@@ -41,6 +30,9 @@ const SequenceRunWorkflowRuns = () => {
         end_time: end_time,
       },
     },
+    reactQuery: {
+      enabled: !!libraryIds?.length,
+    },
   });
   const workflowRunColumn: Column[] = useMemo(
     () => [
@@ -54,7 +46,7 @@ const SequenceRunWorkflowRuns = () => {
           } else {
             return (
               <Link
-                to={`/workflows/workflow/${id}`}
+                to={`/workflows/workflowRuns/${id}`}
                 className={classNames(
                   'flex cursor-pointer flex-row items-center text-sm font-medium text-blue-500 hover:text-blue-700'
                 )}

--- a/src/modules/sequence/components/sequenceRuns/SequenceRunWorkflowRuns.tsx
+++ b/src/modules/sequence/components/sequenceRuns/SequenceRunWorkflowRuns.tsx
@@ -31,7 +31,7 @@ const SequenceRunWorkflowRuns = () => {
       },
     },
     reactQuery: {
-      enabled: !!libraryIds?.length,
+      enabled: !!libraryIds?.length && !!start_time,
     },
   });
   const workflowRunColumn: Column[] = useMemo(

--- a/src/modules/sequence/components/sequenceRuns/SequenceRunWorkflowRunsStats.tsx
+++ b/src/modules/sequence/components/sequenceRuns/SequenceRunWorkflowRunsStats.tsx
@@ -38,7 +38,7 @@ const SequenceRunWorkflowRunsStats = () => {
         },
       },
       reactQuery: {
-        enabled: !!libraryIds?.length,
+        enabled: !!libraryIds?.length && !!start_time,
       },
     });
 

--- a/src/modules/sequence/components/sequenceRuns/SequenceRunWorkflowRunsStats.tsx
+++ b/src/modules/sequence/components/sequenceRuns/SequenceRunWorkflowRunsStats.tsx
@@ -1,10 +1,9 @@
-import { useSequenceRunContext } from './SequenceRunContext';
+import { useSequenceRunWorkflowRunFilter } from './useSequenceRunWorkflowRunFilter';
 import { useWorkflowRunStatusCountModel } from '@/api/workflow';
 import { SpinnerWithText } from '@/components/common/spinner';
 import { classNames } from '@/utils/commonUtils';
 import { QueueListIcon } from '@heroicons/react/24/outline';
 import { useQueryParams } from '@/hooks/useQueryParams';
-import { dayjs } from '@/utils/dayjs';
 const NoWorkflowsFound = () => (
   <div className='flex h-full items-center justify-center rounded-lg border border-gray-200 bg-white p-8 shadow-sm dark:border-gray-700 dark:bg-gray-900'>
     <div className='flex flex-col items-center gap-3 text-center'>
@@ -25,24 +24,9 @@ const NoWorkflowsFound = () => (
 
 const SequenceRunWorkflowRunsStats = () => {
   const { setQueryParams, getQueryParams } = useQueryParams();
-  const { sequenceRunDetail } = useSequenceRunContext();
+  const { libraryIds, start_time, end_time } = useSequenceRunWorkflowRunFilter();
 
   const selectedStatus = getQueryParams().workflowRunStatus;
-
-  // lastest run library ids
-  const libraryIds = sequenceRunDetail?.sort((a, b) => {
-    return dayjs(b.endTime).diff(dayjs(a.endTime));
-  })[0]?.libraries;
-  // time range (first run end time  to 2 days after)
-  const start_time = sequenceRunDetail?.sort((a, b) => {
-    return dayjs(a.endTime).diff(dayjs(b.endTime));
-  })[0]?.endTime;
-  // Set end_time to be 2 days after start_time, but not after now
-  const calculatedEndTime = dayjs(start_time).add(2, 'days');
-  const now = dayjs();
-  const end_time = calculatedEndTime.isAfter(now)
-    ? now.toISOString()
-    : calculatedEndTime.toISOString();
 
   const { data: workflowRunsCount, isLoading: isLoadingWorkflowRuns } =
     useWorkflowRunStatusCountModel({
@@ -52,6 +36,9 @@ const SequenceRunWorkflowRunsStats = () => {
           start_time: start_time,
           end_time: end_time,
         },
+      },
+      reactQuery: {
+        enabled: !!libraryIds?.length,
       },
     });
 
@@ -74,14 +61,6 @@ const SequenceRunWorkflowRunsStats = () => {
       setQueryParams({ workflowRunStatus: status, page: 1 });
     }
   };
-
-  if (!workflowRunsCount) {
-    return (
-      <div className='flex h-full items-center justify-center rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-900'>
-        <p className='text-sm text-gray-500 dark:text-gray-400'>No workflow runs found</p>
-      </div>
-    );
-  }
 
   return (
     <div className='grid grid-cols-7 gap-3 rounded-lg border border-gray-200 bg-white p-4 shadow-xs dark:border-gray-700 dark:bg-gray-900'>

--- a/src/modules/sequence/components/sequenceRuns/useSequenceRunWorkflowRunFilter.ts
+++ b/src/modules/sequence/components/sequenceRuns/useSequenceRunWorkflowRunFilter.ts
@@ -18,9 +18,13 @@ export const useSequenceRunWorkflowRunFilter = () => {
 
   return useMemo(() => {
     // copy before sorting: `sequenceRunDetail` is query cache data and sort() mutates in place
-    const runsByEndTimeAsc = [...(sequenceRunDetail ?? [])].sort((a, b) =>
-      dayjs(a.endTime).diff(dayjs(b.endTime))
-    );
+    // missing endTime sorts last (treated as not-yet-ended, i.e. "latest") rather than
+    // producing an Invalid Date whose diff() is NaN and destabilizes the sort
+    const runsByEndTimeAsc = [...(sequenceRunDetail ?? [])].sort((a, b) => {
+      const aEnd = a.endTime ? dayjs(a.endTime).valueOf() : Number.POSITIVE_INFINITY;
+      const bEnd = b.endTime ? dayjs(b.endTime).valueOf() : Number.POSITIVE_INFINITY;
+      return aEnd - bEnd;
+    });
 
     // time range (first run end time to 2 days after)
     const start_time = runsByEndTimeAsc[0]?.endTime ?? undefined;

--- a/src/modules/sequence/components/sequenceRuns/useSequenceRunWorkflowRunFilter.ts
+++ b/src/modules/sequence/components/sequenceRuns/useSequenceRunWorkflowRunFilter.ts
@@ -1,0 +1,35 @@
+import { useMemo } from 'react';
+import { dayjs } from '@/utils/dayjs';
+import { useSequenceRunContext } from './SequenceRunContext';
+
+/**
+ * Derives the workflow run query filter for the current sequence run:
+ * the libraries of the latest sequence run, and a two day window starting
+ * from the earliest sequence run end time.
+ *
+ * Shared by the stats and the table so both query an identical window, which
+ * keeps their results consistent and lets them share the same query cache entry.
+ *
+ * Every value here is a pure function of `sequenceRunDetail` - never of the
+ * current clock - so the query key stays stable across renders.
+ */
+export const useSequenceRunWorkflowRunFilter = () => {
+  const { sequenceRunDetail } = useSequenceRunContext();
+
+  return useMemo(() => {
+    // copy before sorting: `sequenceRunDetail` is query cache data and sort() mutates in place
+    const runsByEndTimeAsc = [...(sequenceRunDetail ?? [])].sort((a, b) =>
+      dayjs(a.endTime).diff(dayjs(b.endTime))
+    );
+
+    // time range (first run end time to 2 days after)
+    const start_time = runsByEndTimeAsc[0]?.endTime ?? undefined;
+
+    return {
+      // latest run library ids
+      libraryIds: runsByEndTimeAsc[runsByEndTimeAsc.length - 1]?.libraries,
+      start_time,
+      end_time: start_time ? dayjs(start_time).add(2, 'days').toISOString() : undefined,
+    };
+  }, [sequenceRunDetail]);
+};

--- a/src/modules/workflows/routes.tsx
+++ b/src/modules/workflows/routes.tsx
@@ -40,7 +40,9 @@ export const Router: RouteObject = {
     },
     { path: 'workflowRuns/:orcabusId', element: <WorkflowRunsDetailsPage /> },
     { path: 'analysisRuns/:orcabusId', element: <AnalysisRunsDetailsPage /> },
-    { path: '', element: <Navigate to='workflowRuns' replace /> },
-    { path: '*', element: <Navigate to='workflowRuns' replace /> },
+    // absolute paths: a relative `to` inside the splat route below resolves against the
+    // unmatched URL, which makes an unknown path redirect onto itself indefinitely
+    { path: '', element: <Navigate to='/workflows/workflowRuns' replace /> },
+    { path: '*', element: <Navigate to='/workflows/workflowRuns' replace /> },
   ],
 };


### PR DESCRIPTION
Resolve #288 .

## Bug 1 — clicking a workflow run explodes the URL and breadcrumb

**Symptom:** clicking a row navigates to `/workflows/workflow/wfr.01KZ…/workflowRuns/workflowRuns/workflowRuns/…` instead of the details page, and the breadcrumb renders a wall of `workflowRuns` links.

**Cause, part a:** the link pointed at `/workflows/workflow/${id}` — singular, no such route. Every other call site in the repo already used `/workflows/workflowRuns/${id}`.

**Cause, part b:** the unmatched path then hit `{ path: '*', element: <Navigate to='workflowRuns' replace /> }`. In react-router 7.13.2, a relative `to` inside a splat route resolves against the **full matched pathname including the splat value** (`getResolveToMatches` uses `match.pathname`, not `pathnameBase`, for the leaf). So it redirects onto itself forever, appending a segment each time. `replace` means no history stacks up — the URL just grows. The breadcrumb is a symptom: it splits `location.pathname` on `/` and renders one crumb per segment.

**Fix:** corrected the link, and made both fallback redirects absolute. Part (b) is the one that matters beyond this link — with a relative `to`, *any* unknown path under `/workflows` would hang the app the same way.

## Bug 2 — stats bar spins forever and floods the backend

**Symptom:** `SequenceRunWorkflowRunsStats` is stuck on "Loading workflow runs..." and fires an endless stream of `GET /stats/workflow_run/status_counts/` requests. Only on sequence runs finished within the last 2 days.

**Cause:** the query key changed on every render.

```tsx
const now = dayjs();                        // ← re-sampled every render, ms precision
const end_time = calculatedEndTime.isAfter(now)
  ? now.toISOString()                       // ← a brand new string each render
  : calculatedEndTime.toISOString();
```

`openapi-react-query` builds the react-query key from the request init (`[method, path, init]`), so `end_time` is part of the key. Render → new key → new query → observer state update → re-render → new `now` → new key… `isLoading` never goes false and each in-flight fetch is aborted by the next. The `(canceled)` row in the network panel is that abort — the signature of a churning key, not a polling interval.

The `now` branch only fires when `start_time + 2 days > now`, hence recent runs only. The table never clamped to `now`, which is why it loaded fine while the stats bar span.

**Fix:** dropped the clamp rather than memoising around it, so `end_time` is a pure function of `start_time`. Behaviour-equivalent — the schema documents these params as filtering *"start_time/end_time on latest state time"*, and a run's latest state can't be in the future, so the clamp never excluded a row.



## Changes

| File | Change |
|---|---|
| `sequence/components/sequenceRuns/useSequenceRunWorkflowRunFilter.ts` | **New.** Single source of truth for `libraryIds` / `start_time` / `end_time`, memoised on `sequenceRunDetail`. |
| `sequence/components/sequenceRuns/SequenceRunWorkflowRunsStats.tsx` | Uses the hook; `enabled` guard; dropped an unreachable branch. |
| `sequence/components/sequenceRuns/SequenceRunWorkflowRuns.tsx` | Uses the hook; `enabled` guard; fixed link target. |
| `workflows/routes.tsx` | Fallback redirects made absolute. |

Folded into the shared hook:

- **Stopped mutating the query cache.** Both components called `sequenceRunDetail.sort(...)` on react-query's cached array; `sort()` is in-place, so every render reordered shared data twice, in opposite directions.
- **Stats and table now use an identical window.** The stats bar clamped `end_time` and the table didn't, so counts and rows were computed over different ranges. They now emit identical params and share cache entries.
- **`enabled: !!libraryIds?.length`** on both queries, so neither fires an unfiltered request when there are no libraries.
